### PR TITLE
Showcase kustomize setters

### DIFF
--- a/install/Krmfile
+++ b/install/Krmfile
@@ -1,0 +1,16 @@
+apiVersion: config.k8s.io/v1alpha1
+kind: Krmfile
+openAPI:
+  definitions:
+    io.k8s.cli.setters.fqdn:
+      description: full qualified domain name
+      x-k8s-cli:
+        setter:
+          name: fqdn
+          value: "myregistry.mydomain.io"
+    io.k8s.cli.setters.username:
+      description: registry user name
+      x-k8s-cli:
+        setter:
+          name: username
+          value: "myuser"

--- a/install/Krmfile
+++ b/install/Krmfile
@@ -14,3 +14,19 @@ openAPI:
         setter:
           name: username
           value: "myuser"
+    io.k8s.cli.substitutions.fqdn-secret:
+      x-k8s-cli:
+        substitution:
+          name: fqdn-secret
+          pattern: docker-server=${fqdn}
+          values:
+          - marker: ${fqdn}
+            ref: '#/definitions/io.k8s.cli.setters.fqdn'
+    io.k8s.cli.substitutions.username-secret:
+      x-k8s-cli:
+        substitution:
+          name: username-secret
+          pattern: docker-username=${username}
+          values:
+          - marker: ${username}
+            ref: '#/definitions/io.k8s.cli.setters.username'

--- a/install/base/kustomization.yaml
+++ b/install/base/kustomization.yaml
@@ -30,14 +30,20 @@ images:
 
 
 patchesJson6902:
-#    - path: patch-trow-arg.yaml
+#    - patch: |-
+#        - op: replace
+#          path: /spec/template/spec/containers/0/args/2
+#          value: newregistry.mydomain.com
 #      target:
 #        kind: StatefulSet
 #        name: trow-set
 #        group: apps
 #        version: v1
 #
-#    - path: patch-validator-domain.yaml
+#    - patch: |-
+#        - op: replace
+#          path: /webhooks/0/name
+#          value: newregistry.mydomain.com
 #      target:
 #        kind: ValidatingWebhookConfiguration
 #        name: trow-validator

--- a/install/base/kustomization.yaml
+++ b/install/base/kustomization.yaml
@@ -23,29 +23,3 @@ images:
 - name: containersol/trow
   newTag: "0.3"
 
-# The following patches update the domain name in the trow argument and validator without editing
-# the YAML directly.  
-# Create your own version of the patch file with your domain name and reference in your
-# overlay as below:
-
-
-patchesJson6902:
-#    - patch: |-
-#        - op: replace
-#          path: /spec/template/spec/containers/0/args/2
-#          value: newregistry.mydomain.com
-#      target:
-#        kind: StatefulSet
-#        name: trow-set
-#        group: apps
-#        version: v1
-#
-#    - patch: |-
-#        - op: replace
-#          path: /webhooks/0/name
-#          value: newregistry.mydomain.com
-#      target:
-#        kind: ValidatingWebhookConfiguration
-#        name: trow-validator
-#        group: admissionregistration.k8s.io
-#        version: v1

--- a/install/base/patch-trow-arg.yaml
+++ b/install/base/patch-trow-arg.yaml
@@ -1,3 +1,0 @@
-- op: replace
-  path: /spec/template/spec/containers/0/args/2
-  value: newregistry.mydomain.com

--- a/install/base/patch-validator-domain.yaml
+++ b/install/base/patch-validator-domain.yaml
@@ -1,3 +1,0 @@
-- op: replace
-  path: /webhooks/0/name
-  value: newregistry.mydomain.com

--- a/install/base/stateful-set.yaml
+++ b/install/base/stateful-set.yaml
@@ -15,14 +15,14 @@ spec:
       containers:
       - name: trow-pod
         image: containersol/trow:0.3
-        args: 
-          - "--no-tls" 
-          - "-n" 
-          - "myregistry.mydomain.io" 
-          - "-u" 
-          - "myuser" 
-          - "--password-file" 
-          - "/etc/trow/pass"
+        args:
+        - "--no-tls"
+        - "-n"
+        - "myregistry.mydomain.io" # {"$openapi":"fqdn"}
+        - "-u"
+        - "myuser" # {"$openapi":"username"}
+        - "--password-file"
+        - "/etc/trow/pass"
         imagePullPolicy: Always
         ports:
         - containerPort: 8000

--- a/install/base/validate.yaml
+++ b/install/base/validate.yaml
@@ -3,7 +3,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: trow-validator
 webhooks:
-  - name: myregistry.mydomain.com
+  - name: myregistry.mydomain.com # {"$openapi":"fqdn"}
     rules:
       - apiGroups:
           - ""

--- a/install/overlays/cert-manager-nginx/ingress.yaml
+++ b/install/overlays/cert-manager-nginx/ingress.yaml
@@ -10,7 +10,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
 spec:
   rules:
-    - host: myregistry.mydomain.io
+    - host: myregistry.mydomain.io # {"$openapi":"fqdn"}
       http:
         paths:
           - path: /
@@ -19,5 +19,5 @@ spec:
               servicePort: 8000
   tls: 
     - hosts:
-        - myregistry.mydomain.io
+        - myregistry.mydomain.io # {"$openapi":"fqdn"}
       secretName: trow-registry-tls

--- a/install/overlays/cert-manager-nginx/kustomization.yaml
+++ b/install/overlays/cert-manager-nginx/kustomization.yaml
@@ -12,10 +12,15 @@ resources:
 
 
 # The following patches update the domain name in the ingress without editing the yaml. 
-# Create your own version of the patch file with your domain name and reference in your overlay as
-# below:
+# Modify it to your needs:
 #patchesJson6902:
-#    - path: patch-ingress-host.yaml
+#    - patch: |-
+#        - op: replace
+#          path: /spec/rules/0/host
+#          value: newregistry.mydomain.com
+#        - op: replace
+#          path: /spec/tls/0/hosts/0
+#          value: newregistry.mydomain.com
 #      target:
 #          kind: Ingress
 #          name: trow-ingress

--- a/install/overlays/cert-manager-nginx/kustomization.yaml
+++ b/install/overlays/cert-manager-nginx/kustomization.yaml
@@ -10,19 +10,3 @@ bases:
 resources:
     - ingress.yaml
 
-
-# The following patches update the domain name in the ingress without editing the yaml. 
-# Modify it to your needs:
-#patchesJson6902:
-#    - patch: |-
-#        - op: replace
-#          path: /spec/rules/0/host
-#          value: newregistry.mydomain.com
-#        - op: replace
-#          path: /spec/tls/0/hosts/0
-#          value: newregistry.mydomain.com
-#      target:
-#          kind: Ingress
-#          name: trow-ingress
-#          group: extensions
-#          version: v1beta1

--- a/install/overlays/cert-manager-nginx/patch-ingress-host.yaml
+++ b/install/overlays/cert-manager-nginx/patch-ingress-host.yaml
@@ -1,6 +1,0 @@
-- op: replace
-  path: /spec/rules/0/host
-  value: newregistry.mydomain.com
-- op: replace
-  path: /spec/tls/0/hosts/0
-  value: newregistry.mydomain.com

--- a/install/overlays/example-overlay/kustomization.yaml
+++ b/install/overlays/example-overlay/kustomization.yaml
@@ -16,41 +16,7 @@ secretGenerator:
   - name: trow-cred
     type: docker-registry
     literals:
-    - docker-server=example.registry.com
+    - docker-server=example.registry.com # {"$openapi":"fqdn"}
     - docker-username=example
     - docker-password=s3cr3tp@55
 
-patchesJson6902:
-  - patch: |-
-      - op: replace
-        path: /spec/rules/0/host
-        value: example.registry.com
-      - op: replace
-        path: /spec/tls/0/hosts/0
-        value: example.registry.com
-    target:
-      kind: Ingress
-      name: trow-ingress
-      group: extensions
-      version: v1beta1
-  - patch: |-
-      - op: replace #domain name
-        path: /spec/template/spec/containers/0/args/2
-        value: example.registry.com
-      - op: replace #user name
-        path: /spec/template/spec/containers/0/args/4
-        value: example
-    target:
-      kind: StatefulSet
-      name: trow-set
-      group: apps
-      version: v1
-#    - patch: |-
-#        - op: replace
-#          path: /webhooks/0/name
-#          value: example.registry.com
-#      target:
-#        kind: ValidatingWebhookConfiguration
-#        name: trow-validator
-#        group: admissionregistration.k8s.io
-#        version: v1

--- a/install/overlays/example-overlay/kustomization.yaml
+++ b/install/overlays/example-overlay/kustomization.yaml
@@ -16,7 +16,7 @@ secretGenerator:
   - name: trow-cred
     type: docker-registry
     literals:
-    - docker-server=example.registry.com # {"$openapi":"fqdn"}
-    - docker-username=example
+    - docker-server=example.registry.com # {"$openapi":"fqdn-secret"}
+    - docker-username=example # {"$openapi":"username-secret"}
     - docker-password=s3cr3tp@55
 

--- a/install/overlays/example-overlay/kustomization.yaml
+++ b/install/overlays/example-overlay/kustomization.yaml
@@ -21,20 +21,34 @@ secretGenerator:
     - docker-password=s3cr3tp@55
 
 patchesJson6902:
-  - path: patch-ingress-host.yaml
+  - patch: |-
+      - op: replace
+        path: /spec/rules/0/host
+        value: example.registry.com
+      - op: replace
+        path: /spec/tls/0/hosts/0
+        value: example.registry.com
     target:
       kind: Ingress
       name: trow-ingress
       group: extensions
       version: v1beta1
-  - path: patch-trow-arg.yaml
+  - patch: |-
+      - op: replace #domain name
+        path: /spec/template/spec/containers/0/args/2
+        value: example.registry.com
+      - op: replace #user name
+        path: /spec/template/spec/containers/0/args/4
+        value: example
     target:
       kind: StatefulSet
       name: trow-set
       group: apps
       version: v1
-
-#    - path: patch-validator-domain.yaml
+#    - patch: |-
+#        - op: replace
+#          path: /webhooks/0/name
+#          value: example.registry.com
 #      target:
 #        kind: ValidatingWebhookConfiguration
 #        name: trow-validator

--- a/install/overlays/example-overlay/patch-ingress-host.yaml
+++ b/install/overlays/example-overlay/patch-ingress-host.yaml
@@ -1,6 +1,0 @@
-- op: replace
-  path: /spec/rules/0/host
-  value: example.registry.com
-- op: replace
-  path: /spec/tls/0/hosts/0
-  value: example.registry.com

--- a/install/overlays/example-overlay/patch-trow-arg.yaml
+++ b/install/overlays/example-overlay/patch-trow-arg.yaml
@@ -1,6 +1,0 @@
-- op: replace #domain name
-  path: /spec/template/spec/containers/0/args/2
-  value: example.registry.com
-- op: replace #user name
-  path: /spec/template/spec/containers/0/args/4
-  value: example

--- a/install/overlays/gke/cert.yaml
+++ b/install/overlays/gke/cert.yaml
@@ -4,4 +4,4 @@ metadata:
   name: trow-certificate
 spec:
   domains:
-    - myregistry.mydomain.com
+    - myregistry.mydomain.com # {"$openapi":"fqdn"}

--- a/install/overlays/gke/kustomization.yaml
+++ b/install/overlays/gke/kustomization.yaml
@@ -15,11 +15,13 @@ resources:
     - ingress.yaml
 
 # The following patch updates the certificate domain name without editing the yaml. 
-# Create your own version of the patch file with your domain name and reference in your overlay as
-# below:
+# Modify it to your needs:
 
 #patchesJson6902:
-#    - path: patch-cert-domain.yaml
+#    - patch: |-
+#        - op: replace
+#          path: /spec/domains/0
+#          value: newregistry.mydomain.com
 #      target:
 #        kind: ManagedCertificate
 #        name: trow-certificate

--- a/install/overlays/gke/kustomization.yaml
+++ b/install/overlays/gke/kustomization.yaml
@@ -14,16 +14,3 @@ resources:
     - cert.yaml # Needs to be updated with your domain name, see patches below.
     - ingress.yaml
 
-# The following patch updates the certificate domain name without editing the yaml. 
-# Modify it to your needs:
-
-#patchesJson6902:
-#    - patch: |-
-#        - op: replace
-#          path: /spec/domains/0
-#          value: newregistry.mydomain.com
-#      target:
-#        kind: ManagedCertificate
-#        name: trow-certificate
-#        group: networking.gke.io
-#        version: v1beta1

--- a/install/overlays/gke/patch-cert-domain.yaml
+++ b/install/overlays/gke/patch-cert-domain.yaml
@@ -1,3 +1,0 @@
-- op: replace
-  path: /spec/domains/0
-  value: newregistry.mydomain.com


### PR DESCRIPTION
Showcase #183 

`cd ./install`

```console
$ kustomize cfg list-setters .
    NAME             VALUE            SET BY          DESCRIPTION           COUNT
  fqdn       myregistry.mydomain.io            full qualified domain name   6
  username   myuser                            registry user name           1
```

---

```console
$ kustomize cfg set . fqdn registry.example.com
set 6 fields
```

---

```diff
diff --git a/install/Krmfile b/install/Krmfile
index 8f6d616..7ac4924 100644
--- a/install/Krmfile
+++ b/install/Krmfile
@@ -7,7 +7,8 @@ openAPI:
       x-k8s-cli:
         setter:
           name: fqdn
-          value: "myregistry.mydomain.io"
+          value: "registry.example.com"
+          isSet: true
     io.k8s.cli.setters.username:
       description: registry user name
       x-k8s-cli:
diff --git a/install/base/stateful-set.yaml b/install/base/stateful-set.yaml
index f34c456..0dd4f10 100644
--- a/install/base/stateful-set.yaml
+++ b/install/base/stateful-set.yaml
@@ -17,7 +17,7 @@ spec:
         args:
         - "--no-tls"
         - "-n"
-        - "myregistry.mydomain.io" # {"$openapi":"fqdn"}
+        - "registry.example.com" # {"$openapi":"fqdn"}
         - "-u"
         - "myuser" # {"$openapi":"username"}
         - "--password-file"
diff --git a/install/base/validate.yaml b/install/base/validate.yaml
index f1f1602..e7517da 100644
--- a/install/base/validate.yaml
+++ b/install/base/validate.yaml
@@ -3,7 +3,7 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: trow-validator
 webhooks:
-- name: myregistry.mydomain.com # {"$openapi":"fqdn"}
+- name: registry.example.com # {"$openapi":"fqdn"}
   clientConfig:
     service:
       name: trow
diff --git a/install/overlays/cert-manager-nginx/ingress.yaml b/install/overlays/cert-manager-nginx/ingress.yaml
index 6a4a410..5c6f9d2 100644
--- a/install/overlays/cert-manager-nginx/ingress.yaml
+++ b/install/overlays/cert-manager-nginx/ingress.yaml
@@ -10,7 +10,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-send-timeout: "600"
 spec:
   rules:
-  - host: myregistry.mydomain.io # {"$openapi":"fqdn"}
+  - host: registry.example.com # {"$openapi":"fqdn"}
     http:
       paths:
       - backend:
@@ -19,5 +19,5 @@ spec:
         path: /
   tls:
   - hosts:
-    - myregistry.mydomain.io # {"$openapi":"fqdn"}
+    - registry.example.com # {"$openapi":"fqdn"}
     secretName: trow-registry-tls
diff --git a/install/overlays/example-overlay/kustomization.yaml b/install/overlays/example-overlay/kustomization.yaml
index 48c6466..7aa0438 100644
--- a/install/overlays/example-overlay/kustomization.yaml
+++ b/install/overlays/example-overlay/kustomization.yaml
@@ -12,6 +12,6 @@ secretGenerator:
 - name: trow-cred
   type: docker-registry
   literals:
-  - docker-server=example.registry.com # {"$openapi":"fqdn"}
+  - registry.example.com # {"$openapi":"fqdn"}
   - docker-username=example
   - docker-password=s3cr3tp@55
diff --git a/install/overlays/gke/cert.yaml b/install/overlays/gke/cert.yaml
index e0943fc..e3b6957 100644
--- a/install/overlays/gke/cert.yaml
+++ b/install/overlays/gke/cert.yaml
@@ -4,4 +4,4 @@ metadata:
   name: trow-certificate
 spec:
   domains:
-  - myregistry.mydomain.com # {"$openapi":"fqdn"}
+  - registry.example.com # {"$openapi":"fqdn"}

```

---

Oooops... (this is solved via a so called substituters) https://github.com/ContainerSolutions/trow/pull/186/commits/d50752c0fd8a815b0aa31b954e164e6c390493ec
```diff
-  - docker-server=example.registry.com # {"$openapi":"fqdn"}
+  - registry.example.com # {"$openapi":"fqdn"}
```