### PR TITLE
fixup(chart): deduplicate statefulset volume declaration

### DIFF
--- a/charts/trow/templates/statefulset.yaml
+++ b/charts/trow/templates/statefulset.yaml
@@ -67,17 +67,16 @@ spec:
           subPath: validation.yaml
           readOnly: true
       {{- end}}
+      securityContext:
+        runAsUser: 333333
+        runAsGroup: 333333
+        fsGroup: 333333
       volumes:
       {{- if and (.Values.trow.user) (.Values.trow.password) }}
         - name: trow-pass
           secret:
             secretName: {{ include "trow.fullname" . }}-password
       {{- end}}
-      securityContext:
-        runAsUser: 333333
-        runAsGroup: 333333
-        fsGroup: 333333
-      volumes:
       {{- if (not (empty .Values.trow.proxyConfig.config)) }}
         - name: trow-proxy-cfg
           secret:


### PR DESCRIPTION
Some tools (like flux) will error out when a helm chart resource has duplicate key definitions within a map:

```
❯ k describe helmrelease -A| tail -n 10
  Type     Reason  Age                   From             Message
  ----     ------  ----                  ----             -------
  Normal   info    7m47s                 helm-controller  HelmChart 'trow/trow-trow' is not ready
  Warning  error   6m9s (x8 over 7m45s)  helm-controller  Helm install failed: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors:
  line 58: mapping key "volumes" already defined at line 53

Last Helm logs:
  Warning  error  6m9s (x8 over 7m45s)  helm-controller  reconciliation failed: Helm install failed: error while running post render on files: map[string]interface {}(nil): yaml: unmarshal errors:
  line 58: mapping key "volumes" already defined at line 53
  Normal  info  81s (x10 over 7m45s)  helm-controller  Helm install has started
```

This commit coalesces the trow pass definition along with other mount definitions.