### PR TITLE
docs: remove outdated info/links

### DIFF
--- a/docs/HELM_INSTALL.md
+++ b/docs/HELM_INSTALL.md
@@ -1,7 +1,6 @@
 # Helm Install Trow
 
-Use the following instructions to install Trow via [Helm](https://helm.sh). You may also find the
-information in the [standard install instructions](../docs/KUSTOMIZE_INSTALL.md) useful.
+Use the following instructions to install Trow via [Helm](https://helm.sh).
 
 ## Add the Trow Helm Repo
 
@@ -16,7 +15,7 @@ helm install trow trow/trow
 ```
 ## Notes on installation
 
-The Docker client expects to use TLS to push and pull images from registries. 
+The Docker client expects to use TLS to push and pull images from registries.
 This is normally accomplished by exposing Trow via a Kubernetes ingress endpoint with TLS
 configured. How to do this is dependent on the Kubernetes cluster configuration, but the following
 gives examples for GKE managed certificates and cert-manager. Note that you will need a (sub)domain
@@ -47,7 +46,7 @@ an annotation with the name of the certificate e.g:
 ingress:
     enabled: true
     gke: true
-    annotations: 
+    annotations:
         networking.gke.io/managed-certificates: trow-certificate
 ```
 
@@ -69,7 +68,7 @@ ingress:
     enabled: true
     annotations:
         cert-manager.io/cluster-issuer: nameOfClusterIssuer
-    tls: 
+    tls:
     - hosts:
       - myregistry.mydomain.io
       secretName: myingress-cert
@@ -82,26 +81,3 @@ helm install \
     trow \
     trow/trow
 ```
-
-## Configuration
-
-| Parameter                  | Description                                                                                       | Default                                                                    |
-|----------------------------|---------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------|
-| trow.domain                | The Domain that Trow will be served on, you will need to setup the DNS to point to the correct IP | myregistry.mydomain.io                                                     |
-| trow.user                  | admin user name                                                                                   | user                                                                       |
-| trow.password              | admin password                                                                                    | password                                                                   |
-| trow.validatingWebhooks.enabled  | enable the validation webhooks that block unauthorized images                                     | false                                                                      |
-| imagePullSecrets           | secret used to pull the image (not needed if using the default image)                             | []                                                                         |
-| service.type               | type on the service ( ClusterIP, NodePort, LoadBalancer)                                          | NodePort                                                                   |
-| service.port               | Port to expose the service on                                                                     | 8000                                                                       |
-| ingress.enabled            | Enable the ingress setup                                                                          | false                                                                      |
-| ingress.annotations        | List of annotations to set on the ingress                                                         | {}                                                                         |
-| ingress.hosts              | Host configuration for the ingress                                                                | [{host: null, paths: ['/']}}                                               |
-| ingress.gke                | Set to true if you are using GKE's managed SSL certificates                                       | false                                                                      |
-| ingress.tls                | TLS configuration for the Ingress                                                                 | []                                                                         |
-| resources                  | Resource Limits and quotas (currently no limits or requests set)                                  | {}                                                                         |
-| nodeSelector               | Selector to define which nodes to put the pods on                                                 | {}                                                                         |
-| tolerations                | Any toleration values to be set on the pods                                                       | []                                                                         |
-| affinity                   | Any affinity rules to be set on the pod                                                           | {}                                                                         |
-| volumeClaim                | As trow uses a statefulset and uses a volume to store data this can be configured accordingly     | {accessModes: ["ReadWriteOnce"], resources: {requests: {storage: "20Gi"}}} |
-| replicaCount               | Amount of replicas of trow to run                                                                 | 1                                                                          |


### PR DESCRIPTION
As @jglick's comments point out on https://github.com/Trow-Registry/trow/pull/347