### PR TITLE
fix CI runs from forks

### DIFF
--- a/.github/workflows/config/values.yaml
+++ b/.github/workflows/config/values.yaml
@@ -1,6 +1,6 @@
 image:
-  repository: ghcr.io/trow-registry/trow-dev
-  tag: "%TROW_IMAGE_TAG%"
+  repository: trow
+  tag: onpr
 trow:
   domain: "127.0.0.1"
 ingress:

--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -52,25 +52,21 @@ jobs:
         run: |
           cargo build
           mv target/debug/trow trow
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: ghcr.io/trow-registry/trow-dev
-      - name: Build and push container image
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and export container image
         uses: docker/build-push-action@v4
         with:
-          push: true
           context: .
           file: ./docker/Dockerfile.debug
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: trow:onpr
+          outputs: type=docker,dest=/tmp/trow_image.tar.zst
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          retention-days: 1
+          name: "trow-image-${{ github.event.pull_request.number }}"
+          path: /tmp/trow_image.tar.zst
 
 
   oci-conformance:
@@ -80,15 +76,26 @@ jobs:
       SCCACHE_GHA_ENABLED: "true"
       RUSTC_WRAPPER: "sccache"
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-    services:
-      trow:
-        image: ${{ needs.build.outputs.container-image }}
     timeout-minutes: 10
     steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: "trow-image-${{ github.event.pull_request.number }}"
+          path: /tmp
+      - name: Load and run image
+        id: start-container-image
+        run: |
+          docker load --input /tmp/trow_image.tar.zst
+          ID=$(docker run -d --name trow -p 8000:8000 trow:onpr)
+          IP=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $ID)
+          echo "container-ip=$IP" >> $GITHUB_OUTPUT
+      - name: Test connectivity
+        run: curl "http://${{ steps.start-container-image.outputs.container-ip }}:8000"
       - name: Run OCI Distribution Spec conformance tests
         uses: opencontainers/distribution-spec@v1.1.0-rc3
         env:
-          OCI_ROOT_URL: http://trow:8000
+          OCI_ROOT_URL: "http://${{ steps.start-container-image.outputs.container-ip }}:8000"
           OCI_NAMESPACE: oci-conformance/distribution-test
           OCI_TEST_PULL: 1
           OCI_TEST_PUSH: 1
@@ -96,18 +103,6 @@ jobs:
           OCI_TEST_CONTENT_MANAGEMENT: 1
           OCI_HIDE_SKIPPED_WORKFLOWS: 0
           OCI_DEBUG: 0
-
-
-  purge-images:
-    name: Delete old dev images
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/delete-package-versions@v4
-        with:
-          package-name: 'trow-dev'
-          package-type: 'container'
-          min-versions-to-keep: 5
 
 
   helm-chart-validation:

--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -14,7 +14,7 @@ jobs:
       RUSTC_WRAPPER: "sccache"
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: rui314/setup-mold@v1
       - uses: dtolnay/rust-toolchain@stable
       - name: Install Protoc
@@ -41,7 +41,7 @@ jobs:
       container-image: ${{ steps.meta.outputs.tags }}
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: rui314/setup-mold@v1
       - uses: dtolnay/rust-toolchain@stable
       - name: Install Protoc
@@ -78,7 +78,7 @@ jobs:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
     timeout-minutes: 10
     steps:
-      - name: Download artifact
+      - name: Download container image artifact
         uses: actions/download-artifact@v3
         with:
           name: "trow-image-${{ github.event.pull_request.number }}"
@@ -112,24 +112,29 @@ jobs:
       IMAGE: ${{ needs.build.outputs.container-image }}
     timeout-minutes: 10
     steps:
+      - name: Download container image artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: "trow-image-${{ github.event.pull_request.number }}"
+          path: /tmp
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Helm
         uses: azure/setup-helm@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Create kind cluster
-        uses: helm/kind-action@v1.7.0
+        uses: helm/kind-action@v1.8.0
         with:
           config: .github/workflows/config/kind.yaml
+          cluster_name: kind
       - name: Install Ingress
         run: |
           .github/workflows/config/install-kind-ingress.sh
           kubectl delete -A ValidatingWebhookConfiguration ingress-nginx-admission
-      - name: Template values.yaml
+      - name: Sideload Trow image
         run: |
-          IMAGE_TAG="$(echo '${{ env.IMAGE }}' | awk -F':' '{print $2}')"
-          sed -i "s|%TROW_IMAGE_TAG%|$IMAGE_TAG|" .github/workflows/config/values.yaml
+          kind load image-archive /tmp/trow_image.tar.zst
       - name: Helm Install Trow
         run: |
           helm install trow-test -f .github/workflows/config/values.yaml charts/trow/
@@ -147,6 +152,6 @@ jobs:
     name: Typos
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Check spelling
       uses: crate-ci/typos@v1.0.4

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -12,7 +12,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Configure Git

--- a/.github/workflows/tag-trow.yaml
+++ b/.github/workflows/tag-trow.yaml
@@ -15,7 +15,7 @@ jobs:
       packages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
Fix CI failures on PRs from forks by following https://docs.docker.com/build/ci/github-actions/share-image-jobs/ instead of pushing to a "dev" repository.
See https://github.com/orgs/community/discussions/69331