### PR TITLE
Replace manual wilcard path segment handling by new macro: endpoint_fn_7_levels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1986,6 +1986,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
 name = "pem"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3331,6 +3337,7 @@ dependencies = [
  "kube",
  "lazy_static",
  "libc",
+ "paste",
  "predicates",
  "prost",
  "prost-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,4 @@ environment = "^0.1"
 reqwest = { version = "0.11", features = ["blocking", "json", "gzip"] }
 libc = "0.2"
 tempfile = "3"
+paste = "1.0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ tokio-util = { version = "0.7.8", features = ["codec"] }
 hyper = "0.14"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 tracing = "0.1.37"
+paste = "1.0.14"
 
 [dev-dependencies]
 assert_cmd = "2.0"
@@ -58,4 +59,3 @@ environment = "^0.1"
 reqwest = { version = "0.11", features = ["blocking", "json", "gzip"] }
 libc = "0.2"
 tempfile = "3"
-paste = "1.0.14"

--- a/src/routes/blob.rs
+++ b/src/routes/blob.rs
@@ -48,11 +48,11 @@ pub async fn get_blob(
 }
 
 endpoint_fn_7_levels!(
-    get_blob,
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>
-    ;image_name/digest;;
-    -> Result<BlobReader, Error>
+    get_blob(
+        auth_user: TrowToken,
+        state: State<Arc<TrowServerState>>;
+        path: [image_name, digest]
+    ) -> Result<BlobReader, Error>
 );
 
 /*
@@ -122,14 +122,14 @@ pub async fn put_blob(
 }
 
 endpoint_fn_7_levels!(
-    put_blob,
-    headers: HeaderMap,
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>
-    ;image_name/uuid;
-    digest: Query<DigestQuery>,
-    chunk: BodyStream;
-    -> Result<AcceptedUpload, Error>
+    put_blob(
+        headers: HeaderMap,
+        auth_user: TrowToken,
+        state: State<Arc<TrowServerState>>;
+        path: [image_name, uuid],
+        digest: Query<DigestQuery>,
+        chunk: BodyStream
+    ) -> Result<AcceptedUpload, Error>
 );
 
 /*
@@ -182,14 +182,14 @@ pub async fn patch_blob(
 }
 
 endpoint_fn_7_levels!(
-    patch_blob,
-    headers: HeaderMap,
-    auth_user: TrowToken,
-    info: Option<ContentInfo>,
-    state: State<Arc<TrowServerState>>
-    ;image_name/uuid;
-    chunk: BodyStream;
-    -> Result<UploadInfo, Error>
+    patch_blob(
+        headers: HeaderMap,
+        auth_user: TrowToken,
+        info: Option<ContentInfo>,
+        state: State<Arc<TrowServerState>>;
+        path: [image_name, uuid],
+        chunk: BodyStream
+    ) -> Result<UploadInfo, Error>
 );
 
 /*
@@ -250,14 +250,14 @@ pub async fn post_blob_upload(
 }
 
 endpoint_fn_7_levels!(
-    post_blob_upload,
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    headers: HeaderMap,
-    digest: Query<DigestQuery>
-    ;image_name/;
-    data: BodyStream;
-    -> Result<Upload, Error>
+    post_blob_upload(
+        auth_user: TrowToken,
+        state: State<Arc<TrowServerState>>,
+        headers: HeaderMap,
+        digest: Query<DigestQuery>;
+        path: [image_name],
+        data: BodyStream
+    ) -> Result<Upload, Error>
 );
 
 /**
@@ -282,9 +282,9 @@ pub async fn delete_blob(
 }
 
 endpoint_fn_7_levels!(
-    delete_blob,
+    delete_blob(
     auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>
-    ;image_name/digest;
-    ; -> Result<BlobDeleted, Error>
+    state: State<Arc<TrowServerState>>;
+    path: [image_name, digest]
+    ) -> Result<BlobDeleted, Error>
 );

--- a/src/routes/blob.rs
+++ b/src/routes/blob.rs
@@ -5,6 +5,7 @@ use axum::extract::{BodyStream, Path, Query, State};
 use axum::http::header::HeaderMap;
 use tracing::{event, Level};
 
+use super::macros::endpoint_fn_7_levels;
 use crate::registry_interface::{digest, BlobReader, BlobStorage, ContentInfo, StorageDriverError};
 use crate::response::errors::Error;
 use crate::response::get_base_url;
@@ -45,105 +46,14 @@ pub async fn get_blob(
         }
     }
 }
-pub async fn get_blob_2level(
+
+endpoint_fn_7_levels!(
+    get_blob,
     auth_user: TrowToken,
-    State(state): State<Arc<TrowServerState>>,
-    Path((one, two, digest)): Path<(String, String, String)>,
-) -> Result<BlobReader, Error> {
-    get_blob(
-        auth_user,
-        State(state),
-        Path((format!("{one}/{two}"), digest)),
-    )
-    .await
-}
-pub async fn get_blob_3level(
-    auth_user: TrowToken,
-    State(state): State<Arc<TrowServerState>>,
-    Path((one, two, three, digest)): Path<(String, String, String, String)>,
-) -> Result<BlobReader, Error> {
-    get_blob(
-        auth_user,
-        State(state),
-        Path((format!("{one}/{two}/{three}"), digest)),
-    )
-    .await
-}
-pub async fn get_blob_4level(
-    auth_user: TrowToken,
-    State(state): State<Arc<TrowServerState>>,
-    Path((one, two, three, four, digest)): Path<(String, String, String, String, String)>,
-) -> Result<BlobReader, Error> {
-    get_blob(
-        auth_user,
-        State(state),
-        Path((format!("{one}/{two}/{three}/{four}"), digest)),
-    )
-    .await
-}
-pub async fn get_blob_5level(
-    auth_user: TrowToken,
-    State(state): State<Arc<TrowServerState>>,
-    Path((one, two, three, four, five, digest)): Path<(
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-    )>,
-) -> Result<BlobReader, Error> {
-    get_blob(
-        auth_user,
-        State(state),
-        Path((format!("{one}/{two}/{three}/{four}/{five}"), digest)),
-    )
-    .await
-}
-pub async fn get_blob_6level(
-    auth_user: TrowToken,
-    State(state): State<Arc<TrowServerState>>,
-    Path((one, two, three, four, five, six, digest)): Path<(
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-    )>,
-) -> Result<BlobReader, Error> {
-    get_blob(
-        auth_user,
-        State(state),
-        Path((format!("{one}/{two}/{three}/{four}/{five}/{six}"), digest)),
-    )
-    .await
-}
-pub async fn get_blob_7level(
-    auth_user: TrowToken,
-    State(state): State<Arc<TrowServerState>>,
-    Path((one, two, three, four, five, six, seven, digest)): Path<(
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-    )>,
-) -> Result<BlobReader, Error> {
-    get_blob(
-        auth_user,
-        State(state),
-        Path((
-            format!("{one}/{two}/{three}/{four}/{five}/{six}/{seven}"),
-            digest,
-        )),
-    )
-    .await
-}
+    state: State<Arc<TrowServerState>>
+    ;image_name/digest;;
+    -> Result<BlobReader, Error>
+);
 
 /*
 ---
@@ -210,141 +120,17 @@ pub async fn put_blob(
         (0, (size as u32).saturating_sub(1)), // Note first byte is 0
     ))
 }
-pub async fn put_blob_2level(
+
+endpoint_fn_7_levels!(
+    put_blob,
     headers: HeaderMap,
     auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, uuid)): Path<(String, String, String)>,
+    state: State<Arc<TrowServerState>>
+    ;image_name/uuid;
     digest: Query<DigestQuery>,
-    chunk: BodyStream,
-) -> Result<AcceptedUpload, Error> {
-    put_blob(
-        headers,
-        auth_user,
-        state,
-        Path((format!("{one}/{two}"), uuid)),
-        digest,
-        chunk,
-    )
-    .await
-}
-pub async fn put_blob_3level(
-    headers: HeaderMap,
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three, uuid)): Path<(String, String, String, String)>,
-    digest: Query<DigestQuery>,
-    chunk: BodyStream,
-) -> Result<AcceptedUpload, Error> {
-    put_blob(
-        headers,
-        auth_user,
-        state,
-        Path((format!("{one}/{two}/{three}"), uuid)),
-        digest,
-        chunk,
-    )
-    .await
-}
-pub async fn put_blob_4level(
-    headers: HeaderMap,
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three, four, uuid)): Path<(String, String, String, String, String)>,
-    digest: Query<DigestQuery>,
-    chunk: BodyStream,
-) -> Result<AcceptedUpload, Error> {
-    put_blob(
-        headers,
-        auth_user,
-        state,
-        Path((format!("{one}/{two}/{three}/{four}"), uuid)),
-        digest,
-        chunk,
-    )
-    .await
-}
-pub async fn put_blob_5level(
-    headers: HeaderMap,
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three, four, five, uuid)): Path<(
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-    )>,
-    digest: Query<DigestQuery>,
-    chunk: BodyStream,
-) -> Result<AcceptedUpload, Error> {
-    put_blob(
-        headers,
-        auth_user,
-        state,
-        Path((format!("{one}/{two}/{three}/{four}/{five}"), uuid)),
-        digest,
-        chunk,
-    )
-    .await
-}
-pub async fn put_blob_6level(
-    headers: HeaderMap,
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three, four, five, six, uuid)): Path<(
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-    )>,
-    digest: Query<DigestQuery>,
-    chunk: BodyStream,
-) -> Result<AcceptedUpload, Error> {
-    put_blob(
-        headers,
-        auth_user,
-        state,
-        Path((format!("{one}/{two}/{three}/{four}/{five}/{six}"), uuid)),
-        digest,
-        chunk,
-    )
-    .await
-}
-pub async fn put_blob_7level(
-    headers: HeaderMap,
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three, four, five, six, seven, uuid)): Path<(
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-    )>,
-    digest: Query<DigestQuery>,
-    chunk: BodyStream,
-) -> Result<AcceptedUpload, Error> {
-    put_blob(
-        headers,
-        auth_user,
-        state,
-        Path((
-            format!("{one}/{two}/{three}/{four}/{five}/{six}/{seven}"),
-            uuid,
-        )),
-        digest,
-        chunk,
-    )
-    .await
-}
+    chunk: BodyStream;
+    -> Result<AcceptedUpload, Error>
+);
 
 /*
 
@@ -395,146 +181,16 @@ pub async fn patch_blob(
     }
 }
 
-pub async fn patch_blob_2level(
+endpoint_fn_7_levels!(
+    patch_blob,
     headers: HeaderMap,
     auth_user: TrowToken,
     info: Option<ContentInfo>,
-    State(state): State<Arc<TrowServerState>>,
-    Path((one, two, uuid)): Path<(String, String, String)>,
-    chunk: BodyStream,
-) -> Result<UploadInfo, Error> {
-    patch_blob(
-        headers,
-        auth_user,
-        info,
-        State(state),
-        Path((format!("{one}/{two}"), uuid)),
-        chunk,
-    )
-    .await
-}
-
-pub async fn patch_blob_3level(
-    headers: HeaderMap,
-    auth_user: TrowToken,
-    info: Option<ContentInfo>,
-    State(state): State<Arc<TrowServerState>>,
-    Path((one, two, three, uuid)): Path<(String, String, String, String)>,
-    chunk: BodyStream,
-) -> Result<UploadInfo, Error> {
-    patch_blob(
-        headers,
-        auth_user,
-        info,
-        State(state),
-        Path((format!("{one}/{two}/{three}"), uuid)),
-        chunk,
-    )
-    .await
-}
-
-pub async fn patch_blob_4level(
-    headers: HeaderMap,
-    auth_user: TrowToken,
-    info: Option<ContentInfo>,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three, four, uuid)): Path<(String, String, String, String, String)>,
-    chunk: BodyStream,
-) -> Result<UploadInfo, Error> {
-    patch_blob(
-        headers,
-        auth_user,
-        info,
-        state,
-        Path((format!("{one}/{two}/{three}/{four}"), uuid)),
-        chunk,
-    )
-    .await
-}
-
-pub async fn patch_blob_5level(
-    headers: HeaderMap,
-    auth_user: TrowToken,
-    info: Option<ContentInfo>,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three, four, five, uuid)): Path<(
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-    )>,
-    chunk: BodyStream,
-) -> Result<UploadInfo, Error> {
-    patch_blob(
-        headers,
-        auth_user,
-        info,
-        state,
-        Path((format!("{one}/{two}/{three}/{four}/{five}"), uuid)),
-        chunk,
-    )
-    .await
-}
-
-pub async fn patch_blob_6level(
-    headers: HeaderMap,
-    auth_user: TrowToken,
-    info: Option<ContentInfo>,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three, four, five, six, uuid)): Path<(
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-    )>,
-    chunk: BodyStream,
-) -> Result<UploadInfo, Error> {
-    patch_blob(
-        headers,
-        auth_user,
-        info,
-        state,
-        Path((format!("{one}/{two}/{three}/{four}/{five}/{six}"), uuid)),
-        chunk,
-    )
-    .await
-}
-
-pub async fn patch_blob_7level(
-    headers: HeaderMap,
-    auth_user: TrowToken,
-    info: Option<ContentInfo>,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three, four, five, six, seven, uuid)): Path<(
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-    )>,
-    chunk: BodyStream,
-) -> Result<UploadInfo, Error> {
-    patch_blob(
-        headers,
-        auth_user,
-        info,
-        state,
-        Path((
-            format!("{one}/{two}/{three}/{four}/{five}/{six}/{seven}"),
-            uuid,
-        )),
-        chunk,
-    )
-    .await
-}
+    state: State<Arc<TrowServerState>>
+    ;image_name/uuid;
+    chunk: BodyStream;
+    -> Result<UploadInfo, Error>
+);
 
 /*
  Starting point for an uploading a new image or new version of an image.
@@ -592,129 +248,17 @@ pub async fn post_blob_upload(
         (0, 0),
     )))
 }
-pub async fn post_blob_upload_2level(
+
+endpoint_fn_7_levels!(
+    post_blob_upload,
     auth_user: TrowToken,
     state: State<Arc<TrowServerState>>,
     headers: HeaderMap,
-    digest: Query<DigestQuery>,
-    Path((one, two)): Path<(String, String)>,
-    data: BodyStream,
-) -> Result<Upload, Error> {
-    post_blob_upload(
-        auth_user,
-        state,
-        headers,
-        digest,
-        Path(format!("{one}/{two}")),
-        data,
-    )
-    .await
-}
-pub async fn post_blob_upload_3level(
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    headers: HeaderMap,
-    digest: Query<DigestQuery>,
-    Path((one, two, three)): Path<(String, String, String)>,
-    data: BodyStream,
-) -> Result<Upload, Error> {
-    post_blob_upload(
-        auth_user,
-        state,
-        headers,
-        digest,
-        Path(format!("{one}/{two}/{three}")),
-        data,
-    )
-    .await
-}
-pub async fn post_blob_upload_4level(
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    headers: HeaderMap,
-    digest: Query<DigestQuery>,
-    Path((one, two, three, four)): Path<(String, String, String, String)>,
-    data: BodyStream,
-) -> Result<Upload, Error> {
-    post_blob_upload(
-        auth_user,
-        state,
-        headers,
-        digest,
-        Path(format!("{one}/{two}/{three}/{four}")),
-        data,
-    )
-    .await
-}
-pub async fn post_blob_upload_5level(
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    headers: HeaderMap,
-    digest: Query<DigestQuery>,
-    Path((one, two, three, four, five)): Path<(String, String, String, String, String)>,
-    data: BodyStream,
-) -> Result<Upload, Error> {
-    post_blob_upload(
-        auth_user,
-        state,
-        headers,
-        digest,
-        Path(format!("{one}/{two}/{three}/{four}/{five}")),
-        data,
-    )
-    .await
-}
-pub async fn post_blob_upload_6level(
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    headers: HeaderMap,
-    digest: Query<DigestQuery>,
-    Path((one, two, three, four, five, six)): Path<(
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-    )>,
-    data: BodyStream,
-) -> Result<Upload, Error> {
-    post_blob_upload(
-        auth_user,
-        state,
-        headers,
-        digest,
-        Path(format!("{one}/{two}/{three}/{four}/{five}/{six}")),
-        data,
-    )
-    .await
-}
-pub async fn post_blob_upload_7level(
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    headers: HeaderMap,
-    digest: Query<DigestQuery>,
-    Path((one, two, three, four, five, six, seven)): Path<(
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-    )>,
-    data: BodyStream,
-) -> Result<Upload, Error> {
-    post_blob_upload(
-        auth_user,
-        state,
-        headers,
-        digest,
-        Path(format!("{one}/{two}/{three}/{four}/{five}/{six}/{seven}")),
-        data,
-    )
-    .await
-}
+    digest: Query<DigestQuery>
+    ;image_name/;
+    data: BodyStream;
+    -> Result<Upload, Error>
+);
 
 /**
  * Deletes the given blob.
@@ -736,97 +280,11 @@ pub async fn delete_blob(
         .map_err(|_| Error::NotFound)?;
     Ok(BlobDeleted {})
 }
-pub async fn delete_blob_2level(
+
+endpoint_fn_7_levels!(
+    delete_blob,
     auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, digest)): Path<(String, String, String)>,
-) -> Result<BlobDeleted, Error> {
-    delete_blob(auth_user, state, Path((format!("{one}/{two}"), digest))).await
-}
-pub async fn delete_blob_3level(
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three, digest)): Path<(String, String, String, String)>,
-) -> Result<BlobDeleted, Error> {
-    delete_blob(
-        auth_user,
-        state,
-        Path((format!("{one}/{two}/{three}"), digest)),
-    )
-    .await
-}
-pub async fn delete_blob_4level(
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three, four, digest)): Path<(String, String, String, String, String)>,
-) -> Result<BlobDeleted, Error> {
-    delete_blob(
-        auth_user,
-        state,
-        Path((format!("{one}/{two}/{three}/{four}"), digest)),
-    )
-    .await
-}
-pub async fn delete_blob_5level(
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three, four, five, digest)): Path<(
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-    )>,
-) -> Result<BlobDeleted, Error> {
-    delete_blob(
-        auth_user,
-        state,
-        Path((format!("{one}/{two}/{three}/{four}/{five}"), digest)),
-    )
-    .await
-}
-pub async fn delete_blob_6level(
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three, four, five, six, digest)): Path<(
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-    )>,
-) -> Result<BlobDeleted, Error> {
-    delete_blob(
-        auth_user,
-        state,
-        Path((format!("{one}/{two}/{three}/{four}/{five}/{six}"), digest)),
-    )
-    .await
-}
-pub async fn delete_blob_7level(
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three, four, five, six, seven, digest)): Path<(
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-    )>,
-) -> Result<BlobDeleted, Error> {
-    delete_blob(
-        auth_user,
-        state,
-        Path((
-            format!("{one}/{two}/{three}/{four}/{five}/{six}/{seven}"),
-            digest,
-        )),
-    )
-    .await
-}
+    state: State<Arc<TrowServerState>>
+    ;image_name/digest;
+    ; -> Result<BlobDeleted, Error>
+);

--- a/src/routes/catalog.rs
+++ b/src/routes/catalog.rs
@@ -51,12 +51,12 @@ pub async fn list_tags(
     Ok(TagList::new_filled(repo_name, tags))
 }
 endpoint_fn_7_levels!(
-    list_tags,
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>
-    ;image_name/;
-    query: Query<CatalogListQuery>;
-    -> Result<TagList, Error>
+    list_tags(
+        auth_user: TrowToken,
+        state: State<Arc<TrowServerState>>;
+        path: [image_name],
+        query: Query<CatalogListQuery>
+    ) -> Result<TagList, Error>
 );
 
 pub async fn get_manifest_history(
@@ -77,10 +77,10 @@ pub async fn get_manifest_history(
 }
 
 endpoint_fn_7_levels!(
-    get_manifest_history,
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>
-    ;image_name/reference;
-    query: Query<CatalogListQuery>;
-    -> Result<ManifestHistory, Error>
+    get_manifest_history(
+        auth_user: TrowToken,
+        state: State<Arc<TrowServerState>>;
+        path: [image_name, reference],
+        query: Query<CatalogListQuery>
+    ) -> Result<ManifestHistory, Error>
 );

--- a/src/routes/catalog.rs
+++ b/src/routes/catalog.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use axum::extract::{Path, Query, State};
 use serde_derive::Deserialize;
 
+use super::macros::endpoint_fn_7_levels;
 use crate::registry_interface::{CatalogOperations, ManifestHistory};
 use crate::response::errors::Error;
 use crate::response::trow_token::TrowToken;
@@ -49,99 +50,14 @@ pub async fn list_tags(
         .map_err(|_| Error::InternalError)?;
     Ok(TagList::new_filled(repo_name, tags))
 }
-pub async fn list_tags_2level(
+endpoint_fn_7_levels!(
+    list_tags,
     auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two)): Path<(String, String)>,
-    query: Query<CatalogListQuery>,
-) -> Result<TagList, Error> {
-    list_tags(auth_user, state, Path(format!("{one}/{two}")), query).await
-}
-pub async fn list_tags_3level(
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three)): Path<(String, String, String)>,
-    query: Query<CatalogListQuery>,
-) -> Result<TagList, Error> {
-    list_tags(
-        auth_user,
-        state,
-        Path(format!("{one}/{two}/{three}")),
-        query,
-    )
-    .await
-}
-pub async fn list_tags_4level(
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three, four)): Path<(String, String, String, String)>,
-    query: Query<CatalogListQuery>,
-) -> Result<TagList, Error> {
-    list_tags(
-        auth_user,
-        state,
-        Path(format!("{one}/{two}/{three}/{four}")),
-        query,
-    )
-    .await
-}
-pub async fn list_tags_5level(
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three, four, five)): Path<(String, String, String, String, String)>,
-    query: Query<CatalogListQuery>,
-) -> Result<TagList, Error> {
-    list_tags(
-        auth_user,
-        state,
-        Path(format!("{one}/{two}/{three}/{four}/{five}")),
-        query,
-    )
-    .await
-}
-pub async fn list_tags_6level(
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three, four, five, six)): Path<(
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-    )>,
-    query: Query<CatalogListQuery>,
-) -> Result<TagList, Error> {
-    list_tags(
-        auth_user,
-        state,
-        Path(format!("{one}/{two}/{three}/{four}/{five}/{six}")),
-        query,
-    )
-    .await
-}
-pub async fn list_tags_7level(
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three, four, five, six, seven)): Path<(
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-    )>,
-    query: Query<CatalogListQuery>,
-) -> Result<TagList, Error> {
-    list_tags(
-        auth_user,
-        state,
-        Path(format!("{one}/{two}/{three}/{four}/{five}/{six}/{seven}")),
-        query,
-    )
-    .await
-}
+    state: State<Arc<TrowServerState>>
+    ;image_name/;
+    query: Query<CatalogListQuery>;
+    -> Result<TagList, Error>
+);
 
 pub async fn get_manifest_history(
     _auth_user: TrowToken,
@@ -159,117 +75,12 @@ pub async fn get_manifest_history(
         .map_err(|_| Error::InternalError)?;
     Ok(mh)
 }
-pub async fn get_manifest_history_2level(
+
+endpoint_fn_7_levels!(
+    get_manifest_history,
     auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, reference)): Path<(String, String, String)>,
-    query: Query<CatalogListQuery>,
-) -> Result<ManifestHistory, Error> {
-    get_manifest_history(
-        auth_user,
-        state,
-        Path((format!("{one}/{two}"), reference)),
-        query,
-    )
-    .await
-}
-pub async fn get_manifest_history_3level(
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three, reference)): Path<(String, String, String, String)>,
-    query: Query<CatalogListQuery>,
-) -> Result<ManifestHistory, Error> {
-    get_manifest_history(
-        auth_user,
-        state,
-        Path((format!("{one}/{two}/{three}"), reference)),
-        query,
-    )
-    .await
-}
-pub async fn get_manifest_history_4level(
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three, four, reference)): Path<(String, String, String, String, String)>,
-    query: Query<CatalogListQuery>,
-) -> Result<ManifestHistory, Error> {
-    get_manifest_history(
-        auth_user,
-        state,
-        Path((format!("{one}/{two}/{three}/{four}"), reference)),
-        query,
-    )
-    .await
-}
-pub async fn get_manifest_history_5level(
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three, four, five, reference)): Path<(
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-    )>,
-    query: Query<CatalogListQuery>,
-) -> Result<ManifestHistory, Error> {
-    get_manifest_history(
-        auth_user,
-        state,
-        Path((format!("{one}/{two}/{three}/{four}/{five}"), reference)),
-        query,
-    )
-    .await
-}
-pub async fn get_manifest_history_6level(
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three, four, five, six, reference)): Path<(
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-    )>,
-    query: Query<CatalogListQuery>,
-) -> Result<ManifestHistory, Error> {
-    get_manifest_history(
-        auth_user,
-        state,
-        Path((
-            format!("{one}/{two}/{three}/{four}/{five}/{six}"),
-            reference,
-        )),
-        query,
-    )
-    .await
-}
-pub async fn get_manifest_history_7level(
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three, four, five, six, seven, reference)): Path<(
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-    )>,
-    query: Query<CatalogListQuery>,
-) -> Result<ManifestHistory, Error> {
-    get_manifest_history(
-        auth_user,
-        state,
-        Path((
-            format!("{one}/{two}/{three}/{four}/{five}/{six}/{seven}"),
-            reference,
-        )),
-        query,
-    )
-    .await
-}
+    state: State<Arc<TrowServerState>>
+    ;image_name/reference;
+    query: Query<CatalogListQuery>;
+    -> Result<ManifestHistory, Error>
+);

--- a/src/routes/macros.rs
+++ b/src/routes/macros.rs
@@ -44,7 +44,7 @@ macro_rules! replace_expr {
 /// Macro to quickly write functions for image names several layers depp
 /// eg: `nvidia/dcgm/whatever`
 macro_rules! endpoint_fn_7_levels {
-    ($fn_name:ident, $($arg:ident: $t:ty),+; image_name/$($p:ident),*; $($pa:ident: $pt:ty),*; -> $ret:ty) => {
+    ($fn_name:ident($($arg:ident: $t:ty),+; path: [image_name $(,$p:ident)*] $(,$pa:ident: $pt:ty)*) -> $ret:ty) => {
         paste::item! {
             pub async fn [< $fn_name _2level >](
                 $($arg: $t),*,
@@ -171,6 +171,4 @@ macro_rules! endpoint_fn_7_levels {
     };
 }
 
-pub(crate) use route_7_levels;
-pub(crate) use replace_expr;
-pub(crate) use endpoint_fn_7_levels;
+pub(crate) use {endpoint_fn_7_levels, replace_expr, route_7_levels};

--- a/src/routes/macros.rs
+++ b/src/routes/macros.rs
@@ -1,0 +1,176 @@
+/// Macro to easily create routes with many path parameters
+macro_rules! route_7_levels {
+    ($app:ident, $prefix:literal $route:literal, $($method:ident($handler1:expr, $handler2:expr, $handler3:expr, $handler4:expr, $handler5:expr, $handler6:expr, $handler7:expr)),*) => {
+        $app = $app
+            .route(
+                concat!($prefix, "/:one", $route),
+                $($method($handler1)).*
+            )
+            .route(
+                concat!($prefix, "/:one/:two", $route),
+                $($method($handler2)).*
+            )
+            .route(
+                concat!($prefix, "/:one/:two/:three", $route),
+                $($method($handler3)).*,
+            )
+            .route(
+                concat!($prefix, "/:one/:two/:three/:four", $route),
+                $($method($handler4)).*,
+            )
+            .route(
+                concat!($prefix, "/:one/:two/:three/:four/:five", $route),
+                $($method($handler5)).*,
+            )
+            .route(
+                concat!($prefix, "/:one/:two/:three/:four/:five/:six", $route),
+                $($method($handler6)).*,
+            )
+            .route(
+                concat!($prefix, "/:one/:two/:three/:four/:five/:six/:seven", $route),
+                $($method($handler7)).*,
+            )
+            ;
+    };
+}
+
+/// Macro to replace a captured TokenTree by a Type
+macro_rules! replace_expr {
+    ($_t:tt -> $sub:tt) => {
+        $sub
+    };
+}
+
+/// Macro to quickly write functions for image names several layers depp
+/// eg: `nvidia/dcgm/whatever`
+macro_rules! endpoint_fn_7_levels {
+    ($fn_name:ident, $($arg:ident: $t:ty),+; image_name/$($p:ident),*; $($pa:ident: $pt:ty),*; -> $ret:ty) => {
+        paste::item! {
+            pub async fn [< $fn_name _2level >](
+                $($arg: $t),*,
+                Path((one, two, $($p),*)): Path<(
+                    String,
+                    String,
+                    $($crate::routes::macros::replace_expr!(($p) -> String)),*
+                )>,
+                $($pa: $pt),*
+            ) -> $ret {
+                $fn_name(
+                    $($arg),*,
+                    Path((format!("{one}/{two}") $(,$p)*)),
+                    $($pa),*
+                )
+                .await
+            }
+        }
+        paste::item! {
+            pub async fn [< $fn_name _3level >](
+                $($arg: $t),*,
+                Path((one, two, three, $($p),*)): Path<(
+                    String,
+                    String,
+                    String,
+                    $($crate::routes::macros::replace_expr!(($p) -> String)),*
+                )>,
+                $($pa: $pt),*
+            ) -> $ret {
+                $fn_name(
+                    $($arg),*,
+                    Path((format!("{one}/{two}/{three}") $(,$p)*)),
+                    $($pa),*
+                )
+                .await
+            }
+        }
+        paste::item! {
+            pub async fn [< $fn_name _4level >](
+                $($arg: $t),*,
+                Path((one, two, three, four, $($p),*)): Path<(
+                    String,
+                    String,
+                    String,
+                    String,
+                    $($crate::routes::macros::replace_expr!(($p) -> String)),*
+                )>,
+                $($pa: $pt),*
+            ) -> $ret {
+                $fn_name(
+                    $($arg),*,
+                    Path((format!("{one}/{two}/{three}/{four}") $(,$p)*)),
+                    $($pa),*
+                )
+                .await
+            }
+        }
+        paste::item! {
+            pub async fn [< $fn_name _5level >](
+                $($arg: $t),*,
+                Path((one, two, three, four, five, $($p),*)): Path<(
+                    String,
+                    String,
+                    String,
+                    String,
+                    String,
+                    $($crate::routes::macros::replace_expr!(($p) -> String)),*
+                )>,
+                $($pa: $pt),*
+            ) -> $ret {
+                $fn_name(
+                    $($arg),*,
+                    Path((format!("{one}/{two}/{three}/{four}/{five}") $(,$p)*)),
+                    $($pa),*
+                )
+                .await
+            }
+        }
+        paste::item! {
+            pub async fn [< $fn_name _6level >](
+                $($arg: $t),*,
+                Path((one, two, three, four, five, six, $($p),*)): Path<(
+                    String,
+                    String,
+                    String,
+                    String,
+                    String,
+                    String,
+                    $($crate::routes::macros::replace_expr!(($p) -> String)),*
+                )>,
+                $($pa: $pt),*
+            ) -> $ret {
+                $fn_name(
+                    $($arg),*,
+                    Path((format!("{one}/{two}/{three}/{four}/{five}/{six}") $(,$p)*)),
+                    $($pa),*
+                )
+                .await
+            }
+        }
+        paste::item! {
+            pub async fn [< $fn_name _7level >](
+                $($arg: $t),*,
+                Path((one, two, three, four, five, six, seven, $($p),*)): Path<(
+                    String,
+                    String,
+                    String,
+                    String,
+                    String,
+                    String,
+                    String,
+                    $($crate::routes::macros::replace_expr!(($p) -> String)),*
+                )>,
+                $($pa: $pt),*
+            ) -> $ret {
+                $fn_name(
+                    $($arg),*,
+                    Path((format!("{one}/{two}/{three}/{four}/{five}/{six}/{seven}") $(,$p)*)),
+                    $($pa),*
+                )
+                .await
+            }
+        }
+    };
+}
+
+pub(crate) use route_7_levels;
+pub(crate) use replace_expr;
+pub(crate) use endpoint_fn_7_levels;

--- a/src/routes/manifest.rs
+++ b/src/routes/manifest.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use axum::extract::{BodyStream, Path, State};
 use axum::headers::HeaderMap;
 
+use super::macros::endpoint_fn_7_levels;
 use crate::registry_interface::{digest, ManifestReader, ManifestStorage, StorageDriverError};
 use crate::response::errors::Error;
 use crate::response::get_base_url;
@@ -41,103 +42,14 @@ pub async fn get_manifest(
         .await
         .map_err(|_| Error::ManifestUnknown(reference))
 }
-pub async fn get_manifest_2level(
+
+endpoint_fn_7_levels!(
+    get_manifest,
     auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, reference)): Path<(String, String, String)>,
-) -> Result<ManifestReader, Error> {
-    get_manifest(auth_user, state, Path((format!("{one}/{two}"), reference))).await
-}
-pub async fn get_manifest_3level(
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three, reference)): Path<(String, String, String, String)>,
-) -> Result<ManifestReader, Error> {
-    get_manifest(
-        auth_user,
-        state,
-        Path((format!("{one}/{two}/{three}"), reference)),
-    )
-    .await
-}
-pub async fn get_manifest_4level(
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three, four, reference)): Path<(String, String, String, String, String)>,
-) -> Result<ManifestReader, Error> {
-    get_manifest(
-        auth_user,
-        state,
-        Path((format!("{one}/{two}/{three}/{four}"), reference)),
-    )
-    .await
-}
-pub async fn get_manifest_5level(
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three, four, five, reference)): Path<(
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-    )>,
-) -> Result<ManifestReader, Error> {
-    get_manifest(
-        auth_user,
-        state,
-        Path((format!("{one}/{two}/{three}/{four}/{five}"), reference)),
-    )
-    .await
-}
-pub async fn get_manifest_6level(
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three, four, five, six, reference)): Path<(
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-    )>,
-) -> Result<ManifestReader, Error> {
-    get_manifest(
-        auth_user,
-        state,
-        Path((
-            format!("{one}/{two}/{three}/{four}/{five}/{six}"),
-            reference,
-        )),
-    )
-    .await
-}
-pub async fn get_manifest_7level(
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three, four, five, six, seven, reference)): Path<(
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-    )>,
-) -> Result<ManifestReader, Error> {
-    get_manifest(
-        auth_user,
-        state,
-        Path((
-            format!("{one}/{two}/{three}/{four}/{five}/{six}/{seven}"),
-            reference,
-        )),
-    )
-    .await
-}
+    state: State<Arc<TrowServerState>>
+    ;image_name/reference;;
+    -> Result<ManifestReader, Error>
+);
 
 /*
 
@@ -172,132 +84,16 @@ pub async fn put_image_manifest(
         Err(_) => Err(Error::InternalError),
     }
 }
-pub async fn put_image_manifest_2level(
+endpoint_fn_7_levels!(
+    put_image_manifest,
     headers: HeaderMap,
     auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, reference)): Path<(String, String, String)>,
-    chunk: BodyStream,
-) -> Result<VerifiedManifest, Error> {
-    put_image_manifest(
-        headers,
-        auth_user,
-        state,
-        Path((format!("{one}/{two}"), reference)),
-        chunk,
-    )
-    .await
-}
-pub async fn put_image_manifest_3level(
-    headers: HeaderMap,
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three, reference)): Path<(String, String, String, String)>,
-    chunk: BodyStream,
-) -> Result<VerifiedManifest, Error> {
-    put_image_manifest(
-        headers,
-        auth_user,
-        state,
-        Path((format!("{one}/{two}/{three}"), reference)),
-        chunk,
-    )
-    .await
-}
-pub async fn put_image_manifest_4level(
-    headers: HeaderMap,
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three, four, reference)): Path<(String, String, String, String, String)>,
-    chunk: BodyStream,
-) -> Result<VerifiedManifest, Error> {
-    put_image_manifest(
-        headers,
-        auth_user,
-        state,
-        Path((format!("{one}/{two}/{three}/{four}"), reference)),
-        chunk,
-    )
-    .await
-}
-pub async fn put_image_manifest_5level(
-    headers: HeaderMap,
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three, four, five, reference)): Path<(
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-    )>,
-    chunk: BodyStream,
-) -> Result<VerifiedManifest, Error> {
-    put_image_manifest(
-        headers,
-        auth_user,
-        state,
-        Path((format!("{one}/{two}/{three}/{four}/{five}"), reference)),
-        chunk,
-    )
-    .await
-}
-pub async fn put_image_manifest_6level(
-    headers: HeaderMap,
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three, four, five, six, reference)): Path<(
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-    )>,
-    chunk: BodyStream,
-) -> Result<VerifiedManifest, Error> {
-    put_image_manifest(
-        headers,
-        auth_user,
-        state,
-        Path((
-            format!("{one}/{two}/{three}/{four}/{five}/{six}"),
-            reference,
-        )),
-        chunk,
-    )
-    .await
-}
-pub async fn put_image_manifest_7level(
-    headers: HeaderMap,
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three, four, five, six, seven, reference)): Path<(
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-    )>,
-    chunk: BodyStream,
-) -> Result<VerifiedManifest, Error> {
-    put_image_manifest(
-        headers,
-        auth_user,
-        state,
-        Path((
-            format!("{one}/{two}/{three}/{four}/{five}/{six}/{seven}"),
-            reference,
-        )),
-        chunk,
-    )
-    .await
-}
+    state: State<Arc<TrowServerState>>
+    ;image_name/reference;
+    chunk: BodyStream;
+    -> Result<VerifiedManifest, Error>
+);
+
 /*
 ---
 Deleting an Image
@@ -316,97 +112,10 @@ pub async fn delete_image_manifest(
         Err(_) => Err(Error::InternalError),
     }
 }
-pub async fn delete_image_manifest_2level(
+endpoint_fn_7_levels!(
+    delete_image_manifest,
     auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, digest)): Path<(String, String, String)>,
-) -> Result<ManifestDeleted, Error> {
-    delete_image_manifest(auth_user, state, Path((format!("{one}/{two}"), digest))).await
-}
-pub async fn delete_image_manifest_3level(
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three, digest)): Path<(String, String, String, String)>,
-) -> Result<ManifestDeleted, Error> {
-    delete_image_manifest(
-        auth_user,
-        state,
-        Path((format!("{one}/{two}/{three}"), digest)),
-    )
-    .await
-}
-pub async fn delete_image_manifest_4level(
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three, four, digest)): Path<(String, String, String, String, String)>,
-) -> Result<ManifestDeleted, Error> {
-    delete_image_manifest(
-        auth_user,
-        state,
-        Path((format!("{one}/{two}/{three}/{four}"), digest)),
-    )
-    .await
-}
-pub async fn delete_image_manifest_5level(
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three, four, five, digest)): Path<(
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-    )>,
-) -> Result<ManifestDeleted, Error> {
-    delete_image_manifest(
-        auth_user,
-        state,
-        Path((format!("{one}/{two}/{three}/{four}/{five}"), digest)),
-    )
-    .await
-}
-pub async fn delete_image_manifest_6level(
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three, four, five, six, digest)): Path<(
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-    )>,
-) -> Result<ManifestDeleted, Error> {
-    delete_image_manifest(
-        auth_user,
-        state,
-        Path((format!("{one}/{two}/{three}/{four}/{five}/{six}"), digest)),
-    )
-    .await
-}
-pub async fn delete_image_manifest_7level(
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>,
-    Path((one, two, three, four, five, six, seven, digest)): Path<(
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-        String,
-    )>,
-) -> Result<ManifestDeleted, Error> {
-    delete_image_manifest(
-        auth_user,
-        state,
-        Path((
-            format!("{one}/{two}/{three}/{four}/{five}/{six}/{seven}"),
-            digest,
-        )),
-    )
-    .await
-}
+    state: State<Arc<TrowServerState>>
+    ;image_name/digest;;
+    -> Result<ManifestDeleted, Error>
+);

--- a/src/routes/manifest.rs
+++ b/src/routes/manifest.rs
@@ -44,11 +44,11 @@ pub async fn get_manifest(
 }
 
 endpoint_fn_7_levels!(
-    get_manifest,
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>
-    ;image_name/reference;;
-    -> Result<ManifestReader, Error>
+    get_manifest(
+        auth_user: TrowToken,
+        state: State<Arc<TrowServerState>>;
+        path: [image_name, reference]
+    ) -> Result<ManifestReader, Error>
 );
 
 /*
@@ -85,13 +85,13 @@ pub async fn put_image_manifest(
     }
 }
 endpoint_fn_7_levels!(
-    put_image_manifest,
-    headers: HeaderMap,
-    auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>
-    ;image_name/reference;
-    chunk: BodyStream;
-    -> Result<VerifiedManifest, Error>
+    put_image_manifest(
+        headers: HeaderMap,
+        auth_user: TrowToken,
+        state: State<Arc<TrowServerState>>;
+        path: [image_name, reference],
+        chunk: BodyStream
+    ) -> Result<VerifiedManifest, Error>
 );
 
 /*
@@ -113,9 +113,9 @@ pub async fn delete_image_manifest(
     }
 }
 endpoint_fn_7_levels!(
-    delete_image_manifest,
+    delete_image_manifest(
     auth_user: TrowToken,
-    state: State<Arc<TrowServerState>>
-    ;image_name/digest;;
-    -> Result<ManifestDeleted, Error>
+    state: State<Arc<TrowServerState>>;
+    path: [image_name, digest]
+    ) -> Result<ManifestDeleted, Error>
 );

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -2,10 +2,10 @@ mod admission;
 mod blob;
 mod catalog;
 mod health;
+pub mod macros;
 mod manifest;
 mod metrics;
 mod readiness;
-pub mod macros;
 
 use std::str;
 use std::sync::Arc;
@@ -20,6 +20,7 @@ use axum::routing::{get, post, put};
 use axum::Router;
 use hyper::body::HttpBody;
 use hyper::http::HeaderValue;
+use macros::route_7_levels;
 use tower::ServiceBuilder;
 use tower_http::{cors, trace};
 
@@ -27,8 +28,6 @@ use crate::response::errors::Error;
 use crate::response::html::HTML;
 use crate::response::trow_token::{self, TrowToken, ValidBasicToken};
 use crate::TrowServerState;
-use macros::route_7_levels;
-
 
 pub fn create_app(state: super::TrowServerState) -> Router {
     let mut app = Router::new()

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,3 +1,12 @@
+mod admission;
+mod blob;
+mod catalog;
+mod health;
+mod manifest;
+mod metrics;
+mod readiness;
+pub mod macros;
+
 use std::str;
 use std::sync::Arc;
 use std::time::Duration;
@@ -18,49 +27,8 @@ use crate::response::errors::Error;
 use crate::response::html::HTML;
 use crate::response::trow_token::{self, TrowToken, ValidBasicToken};
 use crate::TrowServerState;
+use macros::route_7_levels;
 
-mod admission;
-mod blob;
-mod catalog;
-mod health;
-mod manifest;
-mod metrics;
-mod readiness;
-
-macro_rules! route_7_levels {
-    ($app:ident, $prefix:literal $route:literal, $($method:ident($handler1:expr, $handler2:expr, $handler3:expr, $handler4:expr, $handler5:expr, $handler6:expr, $handler7:expr)),*) => {
-        $app = $app
-            .route(
-                concat!($prefix, "/:one", $route),
-                $($method($handler1)).*
-            )
-            .route(
-                concat!($prefix, "/:one/:two", $route),
-                $($method($handler2)).*
-            )
-            .route(
-                concat!($prefix, "/:one/:two/:three", $route),
-                $($method($handler3)).*,
-            )
-            .route(
-                concat!($prefix, "/:one/:two/:three/:four", $route),
-                $($method($handler4)).*,
-            )
-            .route(
-                concat!($prefix, "/:one/:two/:three/:four/:five", $route),
-                $($method($handler5)).*,
-            )
-            .route(
-                concat!($prefix, "/:one/:two/:three/:four/:five/:six", $route),
-                $($method($handler6)).*,
-            )
-            .route(
-                concat!($prefix, "/:one/:two/:three/:four/:five/:six/:seven", $route),
-                $($method($handler7)).*,
-            )
-            ;
-    };
-}
 
 pub fn create_app(state: super::TrowServerState) -> Router {
     let mut app = Router::new()

--- a/trow-server/src/image.rs
+++ b/trow-server/src/image.rs
@@ -19,7 +19,7 @@ const fn get_image_ref_regex() -> &'static str {
     const NAME_COMPONENT: &str = formatcp!("{ALPHANUMERIC}(?:{SEPARATOR}{ALPHANUMERIC})*");
     const DOMAIN: &str = formatcp!("{DOMAIN_COMPONENT}(?:[.]{DOMAIN_COMPONENT})*(?::[0-9]+)?");
     const DIGEST: &str = "[A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,}";
-    const TAG: &str = r#"[\w][\w.-]{0,127}"#;
+    const TAG: &str = r"[\w][\w.-]{0,127}";
     const NAME: &str = formatcp!("(?:{DOMAIN}/)?{NAME_COMPONENT}(/{NAME_COMPONENT})*");
 
     formatcp!("^(?P<name>{NAME})(?::(?P<tag>{TAG}))?(?:@(?P<digest>{DIGEST}))?$")

--- a/trow-server/src/proxy_auth.rs
+++ b/trow-server/src/proxy_auth.rs
@@ -391,7 +391,10 @@ mod tests {
                 .query_param("scope", "repository:nvidia/cuda:pull,push")
                 .header(
                     AUTHZ_HEADER,
-                    format!("Basic {}", base64::encode("like-this:reign-of-the-septims")),
+                    format!(
+                        "Basic {}",
+                        general_purpose::STANDARD_NO_PAD.encode("like-this:reign-of-the-septims")
+                    ),
                 );
             then.status(200).json_body(json!({
                 "token": token,


### PR DESCRIPTION
Many routes of the CRI look like `/v2/:image_name*/blobs/:digest`.
Axum doesn't support wildcard segments in the middle of a route (rocket didn't either).
The PR replaces manually writing every *_2level, *_3level, etc function by a macro invocation.