### PR TITLE
Point button to Helm Install

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@ gtag('config', 'UA-118393862-1');
         </div>
         <div class="w-100 text-center action lead">
           <p>Available now on GitHub<p/>
-          <a href="https://github.com/Trow-Registry/trow/blob/master/QUICK-INSTALL.md" class="input-btn btn-lg btn-primary">INSTALLATION</a>
+          <a href="https://github.com/Trow-Registry/trow/blob/main/docs/HELM_INSTALL.md" class="input-btn btn-lg btn-primary">HELM INSTALL</a>
           <a href="https://github.com/Trow-Registry/trow/" class="input-btn btn-lg btn-primary">GITHUB PROJECT</a>
         </div>
       </div>


### PR DESCRIPTION
Used to point to install in root of repo - it no longer exists so probably best to point to the Helm Installation page.