### PR TITLE
Support for the referrers api (oci compliance tests fully passing)

### DIFF
--- a/.github/workflows/pr-tests.yaml
+++ b/.github/workflows/pr-tests.yaml
@@ -99,7 +99,7 @@ jobs:
           OCI_NAMESPACE: oci-conformance/distribution-test
           OCI_TEST_PULL: 1
           OCI_TEST_PUSH: 1
-          OCI_TEST_CONTENT_DISCOVERY: 0
+          OCI_TEST_CONTENT_DISCOVERY: 1
           OCI_TEST_CONTENT_MANAGEMENT: 1
           OCI_HIDE_SKIPPED_WORKFLOWS: 0
           OCI_DEBUG: 0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3579,6 +3579,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
+name = "ryu-js"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad97d4ce1560a5e27cec89519dc8300d1aa6035b099821261c651486a19e44d5"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3721,6 +3727,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json_canonicalizer"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18032888bfda612a88f6b9c7c7a12e8168686936702fe584e3f1b1fc7848443a"
+dependencies = [
+ "ryu-js",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "serde_path_to_error"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3728,6 +3745,16 @@ checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
 dependencies = [
  "itoa",
  "serde",
+]
+
+[[package]]
+name = "serde_sqlite_jsonb"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28eb962d30138aa087a29ea05a791232bac2987c854d9b06c91de0dc61e69e7c"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -4593,6 +4620,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "serde_json_canonicalizer",
+ "serde_sqlite_jsonb",
  "serde_yaml_ng",
  "sha2",
  "sqlx",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3579,12 +3579,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
-name = "ryu-js"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad97d4ce1560a5e27cec89519dc8300d1aa6035b099821261c651486a19e44d5"
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3727,17 +3721,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_json_canonicalizer"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18032888bfda612a88f6b9c7c7a12e8168686936702fe584e3f1b1fc7848443a"
-dependencies = [
- "ryu-js",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "serde_path_to_error"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3745,16 +3728,6 @@ checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
 dependencies = [
  "itoa",
  "serde",
-]
-
-[[package]]
-name = "serde_sqlite_jsonb"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28eb962d30138aa087a29ea05a791232bac2987c854d9b06c91de0dc61e69e7c"
-dependencies = [
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -4620,8 +4593,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "serde_json_canonicalizer",
- "serde_sqlite_jsonb",
  "serde_yaml_ng",
  "sha2",
  "sqlx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,9 +65,11 @@ async-trait = "0.1.74"
 walkdir = "2.0"
 rand = "0.8"
 humansize = "2.1"
-sqlx = { version = "0.8", features = ["runtime-tokio", "migrate", "sqlite"] }
+sqlx = { version = "0.8", features = ["runtime-tokio", "migrate", "sqlite", "json"] }
 oci-spec = "0.7.0"
 oci-client = "0.14.0"
+serde_json_canonicalizer = "0.3.0"
+serde_sqlite_jsonb = "0.1.0"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,8 +68,6 @@ humansize = "2.1"
 sqlx = { version = "0.8", features = ["runtime-tokio", "migrate", "sqlite", "json"] }
 oci-spec = "0.7.0"
 oci-client = "0.14.0"
-serde_json_canonicalizer = "0.3.0"
-serde_sqlite_jsonb = "0.1.0"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/migrations/01_initial.sql
+++ b/migrations/01_initial.sql
@@ -7,19 +7,8 @@ CREATE TABLE "manifest" (
     "digest" TEXT NOT NULL PRIMARY KEY,
     -- "size" INTEGER NOT NULL,
     "last_accessed" INTEGER NOT NULL DEFAULT (unixepoch()),
-    "content" BLOB NOT NULL
-) STRICT;
-CREATE TABLE "blob_blob_association" (
-    "parent_digest" TEXT NOT NULL,
-    "parent_is_manifest" INTEGER NOT NULL,
-    "child_digest" TEXT NOT NULL,
-    PRIMARY KEY ("parent_digest", "child_digest")
-    -- FOREIGN KEY ("parent_digest")
-    --     REFERENCES "blob" ("digest")
-    --     ON DELETE CASCADE
-    --     ON UPDATE CASCADE,
-    -- FOREIGN KEY ("child_digest")
-    --     REFERENCES "blob" ("digest")
+    "json" BLOB NOT NULL,
+    "blob" BLOB NOT NULL
 ) STRICT;
 CREATE TABLE "blob_upload" (
     "uuid" TEXT NOT NULL PRIMARY KEY,

--- a/migrations/01_initial.sql
+++ b/migrations/01_initial.sql
@@ -1,40 +1,46 @@
 CREATE TABLE "blob" (
-    "digest" varchar NOT NULL PRIMARY KEY,
-    "size" integer NOT NULL,
-    "is_manifest" boolean NOT NULL,
-    "last_accessed" integer NOT NULL DEFAULT (unixepoch())
-);
+    "digest" TEXT NOT NULL PRIMARY KEY,
+    "size" INTEGER NOT NULL,
+    "last_accessed" INTEGER NOT NULL DEFAULT (unixepoch())
+) STRICT;
+CREATE TABLE "manifest" (
+    "digest" TEXT NOT NULL PRIMARY KEY,
+    -- "size" INTEGER NOT NULL,
+    "last_accessed" INTEGER NOT NULL DEFAULT (unixepoch()),
+    "content" BLOB NOT NULL
+) STRICT;
 CREATE TABLE "blob_blob_association" (
-    "parent_digest" varchar NOT NULL,
-    "child_digest" varchar NOT NULL,
-    PRIMARY KEY ("parent_digest", "child_digest"),
-    FOREIGN KEY ("parent_digest")
-        REFERENCES "blob" ("digest")
-        ON DELETE CASCADE
-        ON UPDATE CASCADE,
-    FOREIGN KEY ("child_digest")
-        REFERENCES "blob" ("digest")
-);
+    "parent_digest" TEXT NOT NULL,
+    "parent_is_manifest" INTEGER NOT NULL,
+    "child_digest" TEXT NOT NULL,
+    PRIMARY KEY ("parent_digest", "child_digest")
+    -- FOREIGN KEY ("parent_digest")
+    --     REFERENCES "blob" ("digest")
+    --     ON DELETE CASCADE
+    --     ON UPDATE CASCADE,
+    -- FOREIGN KEY ("child_digest")
+    --     REFERENCES "blob" ("digest")
+) STRICT;
 CREATE TABLE "blob_upload" (
     "uuid" TEXT NOT NULL PRIMARY KEY,
-    "offset" integer NOT NULL,
-    "updated_at" timestamp_text NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    "repo" varchar NOT NULL
-);
+    "offset" INTEGER NOT NULL,
+    "updated_at" TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "repo" TEXT NOT NULL
+) STRICT;
 CREATE TABLE "repo_blob_association" (
-    "repo_name" varchar NOT NULL,
-    "blob_digest" varchar NOT NULL,
-    PRIMARY KEY ("repo_name", "blob_digest"),
-    FOREIGN KEY ("blob_digest")
-        REFERENCES "blob" ("digest")
-        ON DELETE CASCADE
-);
+    "repo_name" TEXT NOT NULL,
+    "blob_digest" TEXT NOT NULL,
+    PRIMARY KEY ("repo_name", "blob_digest")
+    -- FOREIGN KEY ("blob_digest")
+    --     REFERENCES "blob" ("digest")
+    --     ON DELETE CASCADE
+) STRICT;
 CREATE TABLE "tag" (
-    "tag" varchar NOT NULL,
-    "repo" varchar NOT NULL,
-    "manifest_digest" varchar NOT NULL,
-    CONSTRAINT "IDX_repo_tag" PRIMARY KEY ("repo", "tag"),
-    FOREIGN KEY ("repo", "manifest_digest")
-        REFERENCES "repo_blob_association" ("repo_name", "blob_digest")
-        ON DELETE CASCADE
-);
+    "tag" TEXT NOT NULL,
+    "repo" TEXT NOT NULL,
+    "manifest_digest" TEXT NOT NULL,
+    CONSTRAINT "IDX_repo_tag" PRIMARY KEY ("repo", "tag")
+    -- FOREIGN KEY ("repo", "manifest_digest")
+    --     REFERENCES "repo_blob_association" ("repo_name", "blob_digest")
+    --     ON DELETE CASCADE
+) STRICT;

--- a/migrations/01_initial.sql
+++ b/migrations/01_initial.sql
@@ -5,7 +5,6 @@ CREATE TABLE "blob" (
 ) STRICT;
 CREATE TABLE "manifest" (
     "digest" TEXT NOT NULL PRIMARY KEY,
-    -- "size" INTEGER NOT NULL,
     "last_accessed" INTEGER NOT NULL DEFAULT (unixepoch()),
     "json" BLOB NOT NULL,
     "blob" BLOB NOT NULL
@@ -20,16 +19,10 @@ CREATE TABLE "repo_blob_association" (
     "repo_name" TEXT NOT NULL,
     "blob_digest" TEXT NOT NULL,
     PRIMARY KEY ("repo_name", "blob_digest")
-    -- FOREIGN KEY ("blob_digest")
-    --     REFERENCES "blob" ("digest")
-    --     ON DELETE CASCADE
 ) STRICT;
 CREATE TABLE "tag" (
     "tag" TEXT NOT NULL,
     "repo" TEXT NOT NULL,
     "manifest_digest" TEXT NOT NULL,
     CONSTRAINT "IDX_repo_tag" PRIMARY KEY ("repo", "tag")
-    -- FOREIGN KEY ("repo", "manifest_digest")
-    --     REFERENCES "repo_blob_association" ("repo_name", "blob_digest")
-    --     ON DELETE CASCADE
 ) STRICT;

--- a/src/registry/digest.rs
+++ b/src/registry/digest.rs
@@ -100,6 +100,10 @@ impl Digest {
     pub fn as_str(&self) -> &str {
         &self.0
     }
+
+    pub fn into_string(self) -> String {
+        self.0
+    }
 }
 
 #[cfg(test)]

--- a/src/registry/digest.rs
+++ b/src/registry/digest.rs
@@ -1,4 +1,3 @@
-use std::io::Read;
 use std::{fmt, io};
 
 use lazy_static::lazy_static;
@@ -7,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use sha2::digest::OutputSizeUser;
 use sha2::{Digest as ShaDigest, Sha256};
 use thiserror::Error;
+use tokio::io::{AsyncRead, AsyncReadExt};
 
 // Buffer size for SHA2 hashing
 const BUFFER_SIZE: usize = 1024 * 1024;
@@ -72,17 +72,24 @@ impl Digest {
         &self.0[7..]
     }
 
-    pub fn digest_sha256<R: Read>(mut reader: R) -> io::Result<Digest> {
-        Self::digest::<Sha256, _>(&mut reader)
+    pub async fn digest_sha256<R: AsyncRead + Unpin>(mut reader: R) -> io::Result<Digest> {
+        Self::digest::<Sha256, _>(&mut reader).await
+    }
+
+    pub fn digest_sha256_slice(slice: &[u8]) -> Digest {
+        let hash = hex::encode(Sha256::digest(slice));
+        Self(format!("sha256:{hash}"))
     }
 
     #[allow(clippy::self_named_constructors)]
-    pub fn digest<D: ShaDigest + Default, R: Read>(reader: &mut R) -> io::Result<Digest> {
+    pub async fn digest<D: ShaDigest + Default, R: AsyncRead + Unpin>(
+        reader: &mut R,
+    ) -> io::Result<Digest> {
         let mut digest = D::default();
-        let mut buffer = [0u8; BUFFER_SIZE];
+        let mut buffer = vec![0u8; BUFFER_SIZE];
         let mut n = BUFFER_SIZE;
         while n == BUFFER_SIZE {
-            n = reader.read(&mut buffer)?;
+            n = reader.read(&mut buffer).await?;
             digest.update(&buffer[..n]);
         }
         let hash = hex::encode(digest.finalize());
@@ -108,13 +115,12 @@ impl Digest {
 
 #[cfg(test)]
 mod test {
-    use std::io::BufReader;
 
     use crate::registry::digest::Digest;
 
     #[test]
     fn sha256_digest_test() {
-        let result = Digest::digest_sha256(BufReader::new("hello world".as_bytes())).unwrap();
+        let result = Digest::digest_sha256_slice("hello world".as_bytes());
         assert_eq!(
             &result.0,
             "sha256:b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
@@ -123,7 +129,7 @@ mod test {
 
     #[test]
     fn sha256_digest_empty_test() {
-        let result = Digest::digest_sha256(BufReader::new("".as_bytes())).unwrap();
+        let result = Digest::digest_sha256_slice("".as_bytes());
         assert_eq!(
             result.0,
             "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855".to_string()
@@ -132,10 +138,8 @@ mod test {
 
     #[test]
     fn sha256_digest_brown_fox_test() {
-        let result = Digest::digest_sha256(BufReader::new(
-            "the quick brown fox jumps over the lazy dog".as_bytes(),
-        ))
-        .unwrap();
+        let result =
+            Digest::digest_sha256_slice("the quick brown fox jumps over the lazy dog".as_bytes());
         assert_eq!(
             result.0,
             "sha256:05c6e08f1d9fdafa03147fcb8f82f124c76d2f70e3d989dc8aadb5e7d7450bec".to_string()

--- a/src/registry/manifest.rs
+++ b/src/registry/manifest.rs
@@ -1,8 +1,9 @@
 use std::borrow::Cow;
+use std::collections::HashMap;
 
 use anyhow::Result;
 use lazy_static::lazy_static;
-use oci_spec::image::{ImageIndex, ImageManifest, MediaType};
+use oci_spec::image::{Descriptor, ImageIndex, ImageManifest, MediaType};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
@@ -101,6 +102,30 @@ pub mod manifest_media_type {
 }
 
 impl OCIManifest {
+    #[inline]
+    pub fn subject(&self) -> Option<Descriptor> {
+        match self {
+            OCIManifest::V2(m2) => m2.subject(),
+            OCIManifest::List(list) => list.subject(),
+        }
+        .clone()
+    }
+    #[inline]
+    pub fn artifact_type(&self) -> Option<MediaType> {
+        match self {
+            OCIManifest::V2(m2) => m2.artifact_type(),
+            OCIManifest::List(list) => list.artifact_type(),
+        }
+        .clone()
+    }
+    #[inline]
+    pub fn annotations(&self) -> &Option<HashMap<String, String>> {
+        match self {
+            OCIManifest::V2(m2) => m2.annotations(),
+            OCIManifest::List(list) => list.annotations(),
+        }
+    }
+
     /// Returns a Vector of the digests of all assets referenced in the Manifest
     /// With the exception of digests for "foreign blobs"
     pub fn get_local_asset_digests(&self) -> Vec<String> {

--- a/src/registry/manifest.rs
+++ b/src/registry/manifest.rs
@@ -134,13 +134,7 @@ impl OCIManifest {
                 let mut digests: Vec<String> = m2
                     .layers()
                     .iter()
-                    .filter(|l| {
-                        l.media_type()
-                            != &MediaType::Other(
-                                "application/vnd.docker.image.rootfs.foreign.diff.tar.gzip"
-                                    .to_string(),
-                            )
-                    })
+                    .filter(|l| layer_is_distributable(l.media_type()))
                     .map(|x| x.digest().to_string())
                     .collect();
                 digests.push(m2.config().digest().to_string());
@@ -164,6 +158,17 @@ impl OCIManifest {
             OCIManifest::List(list) => list.media_type(),
         }
     }
+}
+
+pub fn layer_is_distributable(layer: &MediaType) -> bool {
+    let non_distributable = [
+        MediaType::ImageLayerNonDistributable,
+        MediaType::ImageLayerNonDistributableGzip,
+        MediaType::ImageLayerNonDistributableZstd,
+        MediaType::Other("application/vnd.docker.image.rootfs.foreign.diff.tar.gzip".to_string()),
+    ];
+
+    !non_distributable.contains(layer)
 }
 
 #[cfg(test)]

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -59,7 +59,6 @@ impl From<StorageBackendError> for RegistryError {
             }
             StorageBackendError::InvalidContentRange => Self::InvalidContentRange,
             StorageBackendError::InvalidDigest => Self::InvalidDigest,
-            StorageBackendError::InvalidManifest(_msg) => Self::InvalidManifest,
             StorageBackendError::InvalidName(name) => Self::InvalidName(name),
             StorageBackendError::Io(e) => {
                 tracing::error!("Internal IO error: {e:?}");

--- a/src/registry/proxy/proxy_config.rs
+++ b/src/registry/proxy/proxy_config.rs
@@ -4,7 +4,6 @@ use aws_sdk_ecr::config::http::HttpResponse;
 use aws_sdk_ecr::error::SdkError;
 use aws_sdk_ecr::operation::get_authorization_token::GetAuthorizationTokenError;
 use base64::Engine;
-use bytes::Bytes;
 use futures::future::try_join_all;
 use oci_client::client::ClientProtocol;
 use oci_client::secrets::RegistryAuth;
@@ -79,6 +78,14 @@ pub enum DownloadRemoteImageError {
     InvalidDigest(#[from] DigestError),
     #[error("Failed to download image")]
     DownloadAttemptsFailed,
+    #[error("Manifest JSON is not canonicalized")]
+    ManifestNotCanonicalized,
+    #[error("OCI client error: {0}")]
+    OciClientError(#[from] oci_client::errors::OciDistributionError),
+    #[error("Storage backend error: {0}")]
+    StorageError(#[from] crate::registry::storage::StorageBackendError),
+    #[error("Could not deserialize manifest: {0}")]
+    ManifestDeserializationError(#[from] serde_json::Error),
 }
 
 impl SingleRegistryProxyConfig {
@@ -108,7 +115,7 @@ impl SingleRegistryProxyConfig {
         image: &RemoteImage,
         registry: &TrowServer,
         db: &SqlitePool,
-    ) -> Result<Digest, DownloadRemoteImageError> {
+    ) -> Result<(String, OCIManifest), DownloadRemoteImageError> {
         // Replace eg f/docker/alpine by f/docker/library/alpine
         let repo_name = format!("f/{}/{}", self.alias, image.get_repo());
         tracing::debug!("Downloading proxied image {}", repo_name);
@@ -152,20 +159,15 @@ impl SingleRegistryProxyConfig {
 
         for mani_digest in digests.into_iter() {
             let mani_digest_str = mani_digest.as_str();
-            let have_manifest = sqlx::query_scalar!(
-                r#"
-                SELECT EXISTS(
-                    SELECT 1 FROM blob
-                    WHERE digest = $1 AND is_manifest = 1
-                )
-                "#,
+            let try_raw_manifest = sqlx::query_scalar!(
+                "SELECT content FROM manifest WHERE digest = $1",
                 mani_digest_str
             )
-            .fetch_one(&mut *db.acquire().await?)
-            .await?
-                == 1;
-            if have_manifest {
-                return Ok(mani_digest);
+            .fetch_optional(&mut *db.acquire().await?)
+            .await?;
+            if let Some(raw_manifest) = try_raw_manifest {
+                let manifest = serde_json::from_slice::<'_, OCIManifest>(&raw_manifest)?;
+                return Ok((mani_digest.to_string(), manifest));
             }
             if let Some((cl, auth)) = &try_cl {
                 let ref_to_dl = image_ref.clone_with_digest(mani_digest.to_string());
@@ -180,24 +182,23 @@ impl SingleRegistryProxyConfig {
                 )
                 .await;
 
-                if let Err(e) = manifest_download {
-                    tracing::warn!("Failed to download proxied image: {}", e)
-                } else {
-                    if let Some(tag) = image_ref.tag() {
-                        sqlx::query!(
-                            r#"
-                            INSERT INTO tag (repo, tag, manifest_digest)
-                            VALUES ($1, $2, $3)
-                            ON CONFLICT (repo, tag) DO UPDATE SET manifest_digest = $3
-                            "#,
-                            repo_name,
-                            tag,
-                            mani_digest_str
-                        )
-                        .execute(&mut *db.acquire().await?)
-                        .await?;
+                match manifest_download {
+                    Err(e) => tracing::warn!("Failed to download proxied image: {}", e),
+                    Ok(manifest) => {
+                        if let Some(tag) = image_ref.tag() {
+                            sqlx::query!(
+                                r#"INSERT INTO tag (repo, tag, manifest_digest)
+                                VALUES ($1, $2, $3)
+                                ON CONFLICT (repo, tag) DO UPDATE SET manifest_digest = $3"#,
+                                repo_name,
+                                tag,
+                                mani_digest_str
+                            )
+                            .execute(&mut *db.acquire().await?)
+                            .await?;
+                        }
+                        return Ok((mani_digest.to_string(), manifest));
                     }
-                    return Ok(mani_digest);
                 }
             }
         }
@@ -252,8 +253,7 @@ async fn get_aws_ecr_password_from_env(ecr_host: &str) -> Result<String, EcrPass
     Ok(String::from_utf8(auth_str)?)
 }
 
-/// `ref_` MUST reference a digest (*not* a tag)
-// #[async_recursion]
+/// `ref_` MUST reference a digest (_not_ a tag)
 async fn download_manifest_and_layers(
     cl: &oci_client::Client,
     auth: &RegistryAuth,
@@ -261,7 +261,7 @@ async fn download_manifest_and_layers(
     storage: &TrowStorageBackend,
     ref_: &Reference,
     local_repo_name: &str,
-) -> Result<()> {
+) -> Result<OCIManifest, DownloadRemoteImageError> {
     async fn download_blob(
         cl: &oci_client::Client,
         db: SqlitePool,
@@ -269,7 +269,7 @@ async fn download_manifest_and_layers(
         ref_: &Reference,
         layer_digest: &str,
         local_repo_name: &str,
-    ) -> Result<()> {
+    ) -> Result<(), DownloadRemoteImageError> {
         tracing::trace!("Downloading blob {}", layer_digest);
         let already_has_blob = sqlx::query_scalar!(
             "SELECT EXISTS(SELECT 1 FROM blob WHERE digest = $1);",
@@ -286,7 +286,7 @@ async fn download_manifest_and_layers(
                 .await?;
             let size = path.metadata().unwrap().len() as i64;
             sqlx::query!(
-                "INSERT INTO blob (digest, is_manifest, size) VALUES ($1, FALSE, $2) ON CONFLICT DO NOTHING;",
+                "INSERT INTO blob (digest, size) VALUES ($1, $2) ON CONFLICT DO NOTHING;",
                 layer_digest,
                 size
             )
@@ -327,20 +327,18 @@ async fn download_manifest_and_layers(
     let manifest: OCIManifest = serde_json::from_slice(&raw_manifest).map_err(|e| {
         oci_client::errors::OciDistributionError::ManifestParsingError(e.to_string())
     })?;
+    if serde_json_canonicalizer::to_vec(&manifest).unwrap() != raw_manifest {
+        return Err(DownloadRemoteImageError::ManifestNotCanonicalized);
+    }
 
-    let manifest_size = raw_manifest.len() as i64;
-    let already_has_manifest = match sqlx::query!(
-        "INSERT INTO blob (digest, is_manifest, size) VALUES ($1, TRUE, $2);",
+    sqlx::query!(
+        "INSERT INTO manifest (digest, content) VALUES ($1, jsonb($2)) ON CONFLICT DO NOTHING",
         digest,
-        manifest_size
+        raw_manifest
     )
     .execute(&mut *db.acquire().await?)
-    .await
-    {
-        Err(sqlx::Error::Database(e)) if e.is_unique_violation() => true,
-        Err(e) => return Err(e.into()),
-        Ok(_) => false,
-    };
+    .await?;
+    // let already_has_manifest = res.rows_affected() > 0;
 
     sqlx::query!(
         "INSERT INTO repo_blob_association (repo_name, blob_digest) VALUES ($1, $2) ON CONFLICT DO NOTHING;",
@@ -350,17 +348,7 @@ async fn download_manifest_and_layers(
     .execute(&mut *db.acquire().await?)
     .await?;
 
-    if !already_has_manifest {
-        storage
-            .write_image_manifest(
-                Bytes::from(raw_manifest),
-                local_repo_name,
-                &Digest::try_from_raw(&digest).unwrap(),
-            )
-            .await?;
-    }
-
-    match manifest {
+    match &manifest {
         OCIManifest::List(m) => {
             let images_to_dl = m
                 .manifests()
@@ -381,5 +369,5 @@ async fn download_manifest_and_layers(
         }
     }
 
-    Ok(())
+    Ok(manifest)
 }

--- a/src/routes/blob_upload.rs
+++ b/src/routes/blob_upload.rs
@@ -347,8 +347,6 @@ pub fn route(mut app: Router<Arc<TrowServerState>>) -> Router<Arc<TrowServerStat
 #[cfg(test)]
 mod tests {
 
-    use std::io::BufReader;
-
     use axum::body::Body;
     use http_body_util::BodyExt;
     use hyper::Request;
@@ -427,7 +425,7 @@ mod tests {
         );
 
         let blob = "super secret blob".as_bytes();
-        let digest = Digest::digest_sha256(BufReader::new(blob)).unwrap();
+        let digest = Digest::digest_sha256_slice(blob);
         let loc = &format!("/v2/{}/blobs/uploads/{}?digest={}", repo_name, uuid, digest);
 
         let resp = router
@@ -454,7 +452,7 @@ mod tests {
         let repo_name = "test";
 
         let config = "{ }\n".as_bytes();
-        let digest = Digest::digest_sha256(BufReader::new(config)).unwrap();
+        let digest = Digest::digest_sha256_slice(config);
 
         let resp = router
             .clone()

--- a/src/routes/blob_upload.rs
+++ b/src/routes/blob_upload.rs
@@ -70,8 +70,8 @@ mod utils {
         let size_i64 = size.total_stored as i64;
         sqlx::query!(
             r#"
-            INSERT INTO blob (digest, size, is_manifest)
-            VALUES ($1, $2, false) ON CONFLICT (digest) DO NOTHING
+            INSERT INTO blob (digest, size)
+            VALUES ($1, $2) ON CONFLICT (digest) DO NOTHING
             "#,
             digest_str,
             size_i64

--- a/src/routes/catalog.rs
+++ b/src/routes/catalog.rs
@@ -51,6 +51,7 @@ async fn get_catalog(
             .repositories(raw_repos)
             .build()
             .unwrap(),
+        true,
     ))
 }
 
@@ -89,6 +90,7 @@ async fn list_tags(
             .tags(raw_tags)
             .build()
             .unwrap(),
+        true,
     ))
 }
 endpoint_fn_7_levels!(

--- a/src/routes/catalog.rs
+++ b/src/routes/catalog.rs
@@ -51,7 +51,6 @@ async fn get_catalog(
             .repositories(raw_repos)
             .build()
             .unwrap(),
-        true,
     ))
 }
 
@@ -90,7 +89,6 @@ async fn list_tags(
             .tags(raw_tags)
             .build()
             .unwrap(),
-        true,
     ))
 }
 endpoint_fn_7_levels!(

--- a/src/routes/manifest.rs
+++ b/src/routes/manifest.rs
@@ -4,7 +4,6 @@ use axum::body::Body;
 use axum::extract::{Path, State};
 use axum::routing::get;
 use axum::Router;
-use bytes::Buf;
 use digest::Digest;
 
 use super::extracts::AlwaysHost;
@@ -219,7 +218,7 @@ async fn put_image_manifest(
             }
         }
     }
-    let computed_digest = Digest::digest_sha256(manifest_bytes.clone().reader()).unwrap();
+    let computed_digest = Digest::digest_sha256_slice(&manifest_bytes);
     let computed_digest_str = computed_digest.as_str();
     if !is_tag && computed_digest_str != reference {
         return Err(Error::ManifestInvalid(

--- a/src/routes/manifest_referrers.rs
+++ b/src/routes/manifest_referrers.rs
@@ -1,0 +1,219 @@
+use std::str::FromStr;
+use std::sync::Arc;
+
+use axum::extract::{Path, State};
+use axum::routing::get;
+use axum::Router;
+use digest::Digest;
+use oci_spec::image::{Descriptor, ImageIndex, MediaType};
+use sqlx::types::Json;
+
+use super::macros::endpoint_fn_7_levels;
+use super::response::OciJson;
+use crate::registry::digest;
+use crate::registry::manifest::OCIManifest;
+use crate::registry::server::PROXY_DIR;
+use crate::routes::macros::route_7_levels;
+use crate::routes::response::errors::Error;
+use crate::routes::response::trow_token::TrowToken;
+use crate::TrowServerState;
+
+/*
+---
+Listing Referrers
+GET /v2/<name>/referrers/<digest>
+
+# Parameters
+name - The namespace of the repository
+digest - The digest of the manifest specified in the subject field.
+
+# Query Parameters
+(TODO) artifactType: The type of artifact to list referrers for.
+
+ */
+async fn get_referrers(
+    _auth_user: TrowToken,
+    State(state): State<Arc<TrowServerState>>,
+    Path((repo, digest)): Path<(String, String)>,
+) -> Result<OciJson<ImageIndex>, Error> {
+    if repo.starts_with(PROXY_DIR) {
+        return Err(Error::UnsupportedForProxiedRepo);
+    }
+    println!("0");
+    let _ = Digest::try_from_raw(&digest)?;
+    println!("1: {repo} {digest}");
+    let referrers = sqlx::query!(
+        r#"
+        SELECT json(m.content) as "content: Json<OCIManifest>", m.digest
+        FROM manifest m
+        INNER JOIN repo_blob_association rba ON rba.blob_digest = m.digest
+        WHERE rba.repo_name = $1
+            AND (m.content -> 'subject' ->> 'digest') = $2
+        "#,
+        repo,
+        digest
+    )
+    .fetch_all(&mut *state.db.acquire().await?)
+    .await?;
+
+    println!("2: {referrers:?}");
+    let mut descriptors = vec![];
+    for row in referrers {
+        let parsed_manifest = row
+            .content
+            .ok_or_else(|| {
+                Error::ManifestInvalid(format!("deserialization error for {}", row.digest))
+            })?
+            .0;
+
+        let mediatype = parsed_manifest
+            .media_type()
+            .clone()
+            .unwrap_or(MediaType::ImageConfig);
+        let size = serde_json_canonicalizer::to_vec(&parsed_manifest)
+            .unwrap()
+            .len();
+
+        let mut descriptor = Descriptor::new(
+            mediatype,
+            size as u64,
+            oci_spec::image::Digest::from_str(&row.digest).unwrap(),
+        );
+        descriptor.set_artifact_type(parsed_manifest.artifact_type());
+        descriptor.set_annotations(parsed_manifest.annotations().clone());
+        descriptors.push(descriptor);
+    }
+
+    let mut response_manifest = ImageIndex::default();
+    response_manifest.set_manifests(descriptors);
+    response_manifest.set_media_type(Some(MediaType::ImageIndex));
+    let content_type = response_manifest.media_type().as_ref().unwrap().as_ref();
+
+    Ok(OciJson::new(&response_manifest, false).set_content_type(content_type))
+}
+
+endpoint_fn_7_levels!(
+    get_referrers(
+        auth_user: TrowToken,
+        state: State<Arc<TrowServerState>>;
+        path: [image_name, reference: String]
+    ) -> Result<OciJson<ImageIndex>, Error>
+);
+
+pub fn route(mut app: Router<Arc<TrowServerState>>) -> Router<Arc<TrowServerState>> {
+    #[rustfmt::skip]
+    route_7_levels!(
+        app,
+        "/v2" "/referrers/{digest}",
+        get(get_referrers, get_referrers_2level, get_referrers_3level, get_referrers_4level, get_referrers_5level, get_referrers_6level, get_referrers_7level)
+    );
+    app
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use axum::body::Body;
+    use bytes::Buf;
+    use hyper::{Request, StatusCode};
+    use oci_spec::image::{Descriptor, ImageIndex, ImageManifestBuilder, MediaType};
+    use test_temp_dir::test_temp_dir;
+    use tower::ServiceExt;
+
+    use super::*;
+    use crate::test_utilities;
+
+    #[tracing_test::traced_test]
+    #[tokio::test]
+    async fn test_get_referrers() {
+        let tmp_dir = test_temp_dir!();
+        let (state, router) = test_utilities::trow_router(|_| {}, &tmp_dir).await;
+
+        let man_referred = serde_json_canonicalizer::to_vec(&ImageIndex::default()).unwrap();
+        let man_referred_digest = Digest::digest_sha256(man_referred.reader()).unwrap();
+        let subj = serde_json_canonicalizer::to_vec(
+            &ImageManifestBuilder::default()
+                .schema_version(2u32)
+                .layers([])
+                .media_type(MediaType::ImageManifest)
+                .config(Descriptor::new(
+                    MediaType::EmptyJSON,
+                    2,
+                    oci_spec::image::Digest::from_str(
+                        "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+                    )
+                    .unwrap(),
+                ))
+                .subject(Descriptor::new(
+                    MediaType::ImageIndex,
+                    2,
+                    oci_spec::image::Digest::from_str(man_referred_digest.as_str()).unwrap(),
+                ))
+                .build()
+                .unwrap(),
+        )
+        .unwrap();
+        let nosubj = serde_json_canonicalizer::to_vec(
+            &ImageManifestBuilder::default()
+                .schema_version(2u32)
+                .layers([])
+                .media_type(MediaType::ImageManifest)
+                .config(Descriptor::new(
+                    MediaType::EmptyJSON,
+                    2,
+                    oci_spec::image::Digest::from_str(
+                        "sha256:1111111355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+                    )
+                    .unwrap(),
+                ))
+                .build()
+                .unwrap(),
+        )
+        .unwrap();
+
+        for man in [man_referred, subj, nosubj] {
+            let digest = Digest::digest_sha256(man.reader()).unwrap().to_string();
+            sqlx::query!(
+                "INSERT INTO manifest (digest, content) VALUES ($1, jsonb($2))",
+                digest,
+                man,
+            )
+            .execute(&mut *state.db.acquire().await.unwrap())
+            .await
+            .unwrap();
+            sqlx::query!(
+                r#"INSERT INTO repo_blob_association (repo_name, blob_digest) VALUES ("test", $1)"#,
+                digest
+            )
+            .execute(&mut *state.db.acquire().await.unwrap())
+            .await
+            .unwrap();
+        }
+
+        let resp = router
+            .oneshot(
+                Request::get(format!("/v2/test/referrers/{man_referred_digest}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "unexpected status code: {resp:?}"
+        );
+        let val: ImageIndex = test_utilities::response_body_json(resp).await;
+        let descriptors = val.manifests();
+        assert_eq!(descriptors.len(), 1);
+        assert_eq!(
+            descriptors[0].media_type().clone(),
+            MediaType::ImageManifest
+        );
+        assert_eq!(
+            descriptors[0].digest().as_ref(),
+            "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
+        );
+    }
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -5,6 +5,7 @@ mod blob_upload;
 mod catalog;
 mod health;
 mod manifest;
+mod manifest_referrers;
 mod readiness;
 
 // helpers
@@ -131,6 +132,7 @@ pub fn create_app(state: Arc<super::TrowServerState>) -> Router {
     app = blob_upload::route(app);
     app = catalog::route(app);
     app = manifest::route(app);
+    app = manifest_referrers::route(app);
     app = admission::route(app);
 
     app = add_router_layers(app, &state.config.cors);

--- a/src/routes/response/mod.rs
+++ b/src/routes/response/mod.rs
@@ -21,9 +21,7 @@ use std::marker::PhantomData;
 use axum::body::Body;
 use axum::http::{header, HeaderValue};
 use axum::response::{IntoResponse, Response};
-use bytes::Buf;
-
-use crate::registry::Digest;
+use bytes::Bytes;
 
 #[derive(Debug, Default)]
 pub struct OciJson<T> {
@@ -36,33 +34,34 @@ impl<T> OciJson<T>
 where
     T: serde::Serialize,
 {
-    pub fn new(content: &T, compute_digest: bool) -> Self {
-        let body_vec = serde_json_canonicalizer::to_vec(content).unwrap();
-        let digest = if compute_digest {
-            Some(Digest::digest_sha256(body_vec.reader()).unwrap())
-        } else {
-            None
-        };
+    pub fn new(content: &T) -> Self {
+        let body_bytes = serde_json::to_vec(content).unwrap();
+        let content_length = body_bytes.len();
+        let response = Response::new(Body::from(body_bytes));
 
-        let content_length = body_vec.len();
-        let response = Response::new(Body::from(body_vec));
-
-        let s = Self {
+        Self {
             response,
             content_length,
             content_type: PhantomData,
-        };
-        if let Some(digest) = digest {
-            s.set_digest(&digest)
-        } else {
-            s
         }
     }
 
-    pub fn set_digest(mut self, digest: &Digest) -> Self {
+    /// To work around the fact that manifests cannot be serialized/deserialized
+    /// or their digest might not match
+    pub fn new_raw(content: Bytes) -> Self {
+        let content_length = content.len();
+        let response = Response::new(Body::from(content));
+        Self {
+            response,
+            content_length,
+            content_type: PhantomData,
+        }
+    }
+
+    pub fn set_digest<D: AsRef<str>>(mut self, digest: D) -> Self {
         self.response.headers_mut().insert(
             "Docker-Content-Digest",
-            HeaderValue::from_str(digest.as_str()).unwrap(),
+            HeaderValue::from_str(digest.as_ref()).unwrap(),
         );
         self
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -123,16 +123,28 @@ pub struct VerifiedManifest {
     repo_name: String,
     digest: Digest,
     tag: String,
+    subject: Option<String>,
 }
 
 impl VerifiedManifest {
-    pub fn new(base_url: Option<String>, repo_name: String, digest: Digest, tag: String) -> Self {
+    pub fn new(
+        base_url: Option<String>,
+        repo_name: String,
+        digest: Digest,
+        tag: String,
+        subject: Option<String>,
+    ) -> Self {
         Self {
             base_url,
             repo_name,
             digest,
             tag,
+            subject,
         }
+    }
+
+    pub fn subject(&self) -> Option<&String> {
+        self.subject.as_ref()
     }
 
     pub fn digest(&self) -> &str {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2,7 +2,7 @@
 #![allow(dead_code)] // Rustup thinks everything in here is dead code
 
 use std::fs::File;
-use std::io::{BufReader, Read, Write};
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -110,7 +110,7 @@ pub async fn upload_fake_image(cl: &Router, name: &str, tag: &str) -> (Digest, D
     let range = resp.headers().get(RANGE_HEADER).unwrap().to_str().unwrap();
     assert_eq!(range, format!("0-{}", (blob.len() - 1))); //note first byte is 0, hence len - 1
 
-    let blob_digest = Digest::digest_sha256(BufReader::new(blob.as_slice())).unwrap();
+    let blob_digest = Digest::digest_sha256_slice(blob.as_slice());
     let resp = cl
         .clone()
         .oneshot(
@@ -165,7 +165,7 @@ pub async fn upload_fake_image(cl: &Router, name: &str, tag: &str) -> (Digest, D
         }}]
     }}"#
     );
-    let manifest_digest = Digest::digest_sha256(BufReader::new(raw_manifest.as_bytes())).unwrap();
+    let manifest_digest = Digest::digest_sha256_slice(raw_manifest.as_bytes());
     let _: manifest::OCIManifest = serde_json::from_str(&raw_manifest).unwrap();
 
     let manifest_addr = format!("/v2/{}/manifests/{}", name, tag);

--- a/tests/proxy_registry.rs
+++ b/tests/proxy_registry.rs
@@ -170,12 +170,10 @@ mod proxy_registry {
         // Special case: docker/library
         // check that it works and that manifests are written in the correct location
         get_manifest(&trow, "f/docker/alpine", "3.13.4").await;
-        let digest = sqlx::query_scalar!("SELECT manifest_digest FROM tag WHERE repo = 'f/docker/library/alpine' AND tag = '3.13.4'")
+        sqlx::query_scalar!("SELECT manifest_digest FROM tag WHERE repo = 'f/docker/library/alpine' AND tag = '3.13.4'")
             .fetch_one(&mut *state.db.acquire().await.unwrap())
             .await
             .expect("Tag not found in database");
-        let file = data_dir.join(format!("./blobs/{digest}"));
-        assert!(file.exists());
     }
 
     #[tokio::test]

--- a/tests/registry_interface.rs
+++ b/tests/registry_interface.rs
@@ -2,7 +2,6 @@
 mod common;
 
 mod registry_interface {
-    use std::io::BufReader;
 
     use axum::body::Body;
     use axum::http::HeaderValue;
@@ -187,7 +186,7 @@ mod registry_interface {
 
         //used by oci_manifest_test
         let config = "{}\n".as_bytes();
-        let digest = digest::Digest::digest_sha256(BufReader::new(config)).unwrap();
+        let digest = digest::Digest::digest_sha256_slice(config);
         let loc = &format!("/v2/{}/blobs/uploads/{}?digest={}", name, uuid, digest);
 
         let resp = cl
@@ -207,7 +206,7 @@ mod registry_interface {
 
     async fn upload_blob_with_post(cl: &Router, repo_name: &str) {
         let blob_content = "{ }\n".as_bytes();
-        let digest = digest::Digest::digest_sha256(BufReader::new(blob_content)).unwrap();
+        let digest = digest::Digest::digest_sha256_slice(blob_content);
 
         let resp = cl
             .clone()
@@ -234,7 +233,7 @@ mod registry_interface {
     async fn push_oci_manifest(cl: &Router, name: &str, tag: &str) -> String {
         //Note config was uploaded as blob in earlier test
         let config = "{ }\n".as_bytes();
-        let config_digest = digest::Digest::digest_sha256(BufReader::new(config)).unwrap();
+        let config_digest = digest::Digest::digest_sha256_slice(config);
 
         let manifest = format!(
             r#"{{ "mediaType": "application/vnd.oci.image.manifest.v1+json",
@@ -258,7 +257,7 @@ mod registry_interface {
         assert_eq!(resp.status(), StatusCode::CREATED);
 
         // Try pulling by digest
-        let digest = digest::Digest::digest_sha256(BufReader::new(manifest.as_bytes())).unwrap();
+        let digest = digest::Digest::digest_sha256_slice(manifest.as_bytes());
         digest.to_string()
     }
 
@@ -295,7 +294,7 @@ mod registry_interface {
         assert_eq!(resp.status(), StatusCode::CREATED);
 
         // Try pulling by digest
-        let digest = digest::Digest::digest_sha256(BufReader::new(manifest.as_bytes())).unwrap();
+        let digest = digest::Digest::digest_sha256_slice(manifest.as_bytes());
         digest.to_string()
     }
 
@@ -306,7 +305,7 @@ mod registry_interface {
     ) -> String {
         //Note config was uploaded as blob in earlier test
         let config = "{ }\n".as_bytes();
-        let config_digest = digest::Digest::digest_sha256(BufReader::new(config)).unwrap();
+        let config_digest = digest::Digest::digest_sha256_slice(config);
 
         upload_blob_with_post(cl, repo_name).await;
 
@@ -341,7 +340,7 @@ mod registry_interface {
         assert_eq!(resp.status(), StatusCode::CREATED);
 
         // Try pulling by digest
-        let digest = digest::Digest::digest_sha256(BufReader::new(manifest.as_bytes())).unwrap();
+        let digest = digest::Digest::digest_sha256_slice(manifest.as_bytes());
         digest.to_string()
     }
 


### PR DESCRIPTION
- change how manifests are handled:
  - before: they were special blobs
  - now: they're a different object in the DB, not written on disk
- compute digest on AsyncRead onstead of blocking
- add referrers API endpoint (very basic, no pagination)