### PR TITLE
helm: stop creating false releases and tags, use OCI

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -4,26 +4,76 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'charts/**'
+      - '.github/workflows/push.yaml'
+  workflow_dispatch:
 
 jobs:
-  release-helm:
+  build-and-push:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      packages: write
+
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-      - name: Set up Helm
+
+      - name: Install Helm
         uses: azure/setup-helm@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.6.0
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if chart version exists
+        id: check-version
+        run: |
+          # Extract chart name and version
+          CHART_NAME=$(yq eval '.name' ./charts/trow/Chart.yaml)
+          CHART_VERSION=$(yq eval '.version' ./charts/trow/Chart.yaml)
+
+          # Set output variables
+          echo "chart_name=${CHART_NAME}" >> $GITHUB_OUTPUT
+          echo "chart_version=${CHART_VERSION}" >> $GITHUB_OUTPUT
+
+          # Try to pull the existing version
+          if helm pull oci://ghcr.io/trow-registry/charts/${CHART_NAME} --version ${CHART_VERSION} 2>/dev/null; then
+            echo "Version ${CHART_VERSION} of chart already exists in registry"
+            echo "exists=true" >> $GITHUB_OUTPUT
+            exit 0
+          else
+            echo "Version ${CHART_VERSION} of chart does not exist in registry"
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Update Helm dependencies
+        if: steps.check-version.outputs.exists == 'false'
+        run: |
+          cd ./charts/trow
+          helm dependency update
+
+      - name: Package Helm chart
+        if: steps.check-version.outputs.exists == 'false'
+        run: |
+          helm package ./charts/trow
+
+      - name: Push Helm chart
+        if: steps.check-version.outputs.exists == 'false'
+        run: |
+          # Push to GHCR using OCI format
+          helm push ${{ steps.check-version.outputs.chart_name }}-${{ steps.check-version.outputs.chart_version }}.tgz \
+            oci://ghcr.io/trow-registry/charts
+
+      - name: Create and push tag
+        if: steps.check-version.outputs.exists == 'false'
+        run: |
+          TAG_NAME="chart-v${{ steps.check-version.outputs.chart_version }}"
+          git tag -a "$TAG_NAME" -m "Release chart version ${{ steps.check-version.outputs.chart_version }}"
+          git push origin "$TAG_NAME"

--- a/charts/trow/values.yaml
+++ b/charts/trow/values.yaml
@@ -90,7 +90,6 @@ service:
 
 ingress:
   enabled: false
-  gke: false
   annotations:
     {}
     # kubernetes.io/ingress.class: nginx

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,6 +33,11 @@ RUN --mount=type=cache,target=./target \
 
 
 FROM debian:bookworm-slim
+
+LABEL org.opencontainers.image.source="https://github.com/trow-registry/trow"
+LABEL org.opencontainers.image.description="Caching Container Registry and Image Management for Kubernetes Clusters"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
 RUN groupadd -r -g 2000 trow &&\
     useradd -r -g trow -u 2000 trow
 

--- a/docs/HELM_INSTALL.md
+++ b/docs/HELM_INSTALL.md
@@ -2,16 +2,10 @@
 
 Use the following instructions to install Trow via [Helm](https://helm.sh).
 
-## Add the Trow Helm Repo
-
-```bash
-helm repo add trow https://trow.io
-```
-
 ## Install Trow with Helm
 
 ```bash
-helm install trow trow/trow
+helm install trow oci://ghcr.io/trow-registry/charts/trow
 ```
 ## Notes on installation
 
@@ -45,7 +39,6 @@ an annotation with the name of the certificate e.g:
 # values.yaml
 ingress:
     enabled: true
-    gke: true
     annotations:
         networking.gke.io/managed-certificates: trow-certificate
 ```


### PR DESCRIPTION
This removes the horrible `helm/chart-releaser-action`, meaning:
* no more confusing "releases"
* better tag name