### PR TITLE
sqlite: separate rw and ro connection pools

### DIFF
--- a/src/init_db.rs
+++ b/src/init_db.rs
@@ -14,7 +14,7 @@ pub async fn init_db(filename: &str) -> Result<(SqlitePool, SqlitePool), Migrate
         .await?;
 
     let reader_conn = SqlitePoolOptions::new()
-        .connect_with(options) // Maybe I could use the option .read_only(true) here ?
+        .connect_with(options.read_only(true))
         .await?;
 
     sqlx::migrate!().run(&writer_conn).await?;

--- a/src/routes/blob.rs
+++ b/src/routes/blob.rs
@@ -29,7 +29,6 @@ async fn get_blob(
     State(state): State<Arc<TrowServerState>>,
     Path((mut repo, digest)): Path<(String, Digest)>,
 ) -> Result<BlobReader<impl tokio::io::AsyncRead>, Error> {
-    let mut conn = state.db.acquire().await?;
     let digest_str = digest.as_str();
     if repo.starts_with(PROXY_DIR) {
         let (proxy_cfg, image) = match state
@@ -57,7 +56,7 @@ async fn get_blob(
         digest_str,
         repo
     )
-    .fetch_one(&mut *conn)
+    .fetch_one(&state.db_ro)
     .await?;
 
     let stream = match state.registry.storage.get_blob_stream(&repo, &digest).await {

--- a/src/routes/catalog.rs
+++ b/src/routes/catalog.rs
@@ -24,7 +24,6 @@ async fn get_catalog(
     State(state): State<Arc<TrowServerState>>,
     Query(query): Query<CatalogListQuery>,
 ) -> Result<OciJson<RepositoryList>, Error> {
-    let mut conn = state.db.acquire().await?;
     let last_name = match &query.last {
         Some(l) => l,
         None => "",
@@ -41,7 +40,7 @@ async fn get_catalog(
         last_name,
         limit
     )
-    .fetch_all(&mut *conn)
+    .fetch_all(&state.db_ro)
     .await?;
     let raw_repos = repos.into_iter().map(|r| r.repo_name).collect::<Vec<_>>();
 
@@ -59,7 +58,6 @@ async fn list_tags(
     Path(repo_name): Path<String>,
     Query(query): Query<CatalogListQuery>,
 ) -> Result<OciJson<TagList>, Error> {
-    let mut conn = state.db.acquire().await?;
     let last_tag = match &query.last {
         Some(l) => l,
         None => "",
@@ -78,7 +76,7 @@ async fn list_tags(
         last_tag,
         limit
     )
-    .fetch_all(&mut *conn)
+    .fetch_all(&state.db_ro)
     .await?;
     let raw_tags = tags.into_iter().map(|t| t.tag).collect::<Vec<_>>();
 

--- a/src/routes/manifest_referrers.rs
+++ b/src/routes/manifest_referrers.rs
@@ -53,7 +53,7 @@ async fn get_referrers(
         repo,
         digest
     )
-    .fetch_all(&mut *state.db.acquire().await?)
+    .fetch_all(&state.db_ro)
     .await?;
 
     let mut descriptors = vec![];
@@ -170,14 +170,14 @@ mod tests {
                 digest,
                 man,
             )
-            .execute(&mut *state.db.acquire().await.unwrap())
+            .execute(&state.db_rw)
             .await
             .unwrap();
             sqlx::query!(
                 r#"INSERT INTO repo_blob_association (repo_name, blob_digest) VALUES ("test", $1)"#,
                 digest
             )
-            .execute(&mut *state.db.acquire().await.unwrap())
+            .execute(&state.db_rw)
             .await
             .unwrap();
         }

--- a/tests/proxy_registry.rs
+++ b/tests/proxy_registry.rs
@@ -174,7 +174,7 @@ mod proxy_registry {
         // check that it works and that manifests are written in the correct location
         get_manifest(&trow, "f/docker/alpine", "3.13.4").await;
         sqlx::query_scalar!("SELECT manifest_digest FROM tag WHERE repo = 'f/docker/library/alpine' AND tag = '3.13.4'")
-            .fetch_one(&mut *state.db.acquire().await.unwrap())
+            .fetch_one(&state.db_ro)
             .await
             .expect("Tag not found in database");
     }
@@ -217,7 +217,7 @@ mod proxy_registry {
         // Check that tags get updated to point to latest digest
         let (man_3_13, digest_3_13) = get_manifest(&trow, "f/docker/alpine", "3.13.4").await;
         sqlx::query!("INSERT INTO tag (repo, tag, manifest_digest) VALUES ('f/docker/library/alpine', 'latest', $1)", digest_3_13)
-            .execute(&mut *state.db.acquire().await.unwrap())
+            .execute(&state.db_rw)
             .await
             .expect("Failed to insert tag");
 


### PR DESCRIPTION
This allows more throughput.
This PR also updates places where the code was holding an rw connection for too long. 