### PR TITLE
update markdown user documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,36 @@
+# Trow
+
 [![Tests](https://github.com/trow-registry/trow/actions/workflows/pr-tests.yaml/badge.svg)](https://github.com/trow-registry/trow/actions/workflows/pr-tests.yaml)
 
-# Trow
-Image Management for Kubernetes.
-Forked from https://github.com/ContainerSolutions/trow
+Image management and caching for Kubernetes.
 
-We're building an image management solution for Kubernetes (and possibly other orchestrators).
-At its heart is the Trow Registry, which runs inside the cluster, is simple to set-up and fully
-integrated with Kubernetes, including support for auditing and RBAC.
-
-### Why "Trow"
-
-"Trow" is a word with multiple, divergent meanings. In Shetland folklore a trow
-is a small, mischievous creature, similar to the Scandinavian troll. In England,
-it is an old style of cargo boat that transported goods on rivers. Finally, it is
-an archaic word meaning "to think, believe, or trust". The reader is free to
-choose which interpretation they like most, but it should be pronounced to rhyme
-with "brow".
+We're building a small registry to make image management in Kubernetes easy.
+The Trow Registry runs inside the cluster with very little resources, and is simple to set-up
+so it caches every image.
 
 ## Use Cases
 
-The primary goal for Trow is to create a registry that runs within Kubernetes
-and provides a secure and fast way to get containers running on the cluster.
-
-A major focus is providing controls for cluster administrators to define which images
-can run in the cluster. Trow can prevent unauthorised and potentially insecure or malicious
-images from touching your cluster.
+* Spin up a lightweight registry within Kubernetes
+* Cache every image in a cluster, thanks to the mutating webhook
+* Prevent unauthorized images form touching the cluster with the admission webhook
 
 Features include:
 
- - [x] conforms to the [OCI Distribution Specification](https://github.com/opencontainers/distribution-spec) for registries
- - [x] controls images running inside the cluster via approve/deny lists
- - [x] automagically proxies any registry
- - [ ] full auditing and authentication of image access _(in progress)_
- - [ ] distributed architecture for HA and scalability _(planned)_
+- [x] conforms to the [OCI Distribution Specification](https://github.com/opencontainers/distribution-spec) for registries
+- [x] controls images running inside the cluster via approve/deny lists
+- [x] automagically proxy any registry
+- [ ] distributed architecture for HA and scalability _(coming soon)_
+- [ ] full auditing and authentication of image access _(planned)_
 
 ## Comparison to Other Registries
 
-There is a [short article on how Trow compares to other registries](docs/COMPARISON.md), including Harbor.
+See [COMPARISON.md](docs/COMPARISON.md).
 
 ## Install
 
 A [helm chart is available](./charts/trow).
 
-Note that Trow is currently alpha and you can expect to find rough edges.
+Note that Trow is currently beta and you can expect to find rough edges.
 
 ## Architecture and Design
 
@@ -65,6 +53,11 @@ Please take a look at [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to h
 All participants in the Trow project are expected to comply with the [code of
 conduct](CODE_OF_CONDUCT.md).
 
-## Notes
+## Why "Trow"
 
-- The project currently runs on Rust Nightly.
+"Trow" is a word with multiple, divergent meanings. In Shetland folklore a trow
+is a small, mischievous creature, similar to the Scandinavian troll. In England,
+it is an old style of cargo boat that transported goods on rivers. Finally, it is
+an archaic word meaning "to think, believe, or trust". The reader is free to
+choose which interpretation they like most, but it should be pronounced to rhyme
+with "brow".

--- a/docs/COMPARISON.md
+++ b/docs/COMPARISON.md
@@ -1,15 +1,17 @@
-# Comparison to Other Registries
+# Comparison
+
+## To other Registries (Harbor, ECR, ...)
 
 Most registries can be categorised into one or more of the following buckets:
 
- - Public registries such as Docker Hub and Quay.io
- - Cloud Provider registries such as GCR, ECR, ACR etc.
- - Self-hosted registries such as Docker Distribution and Harbor.
+- Public registries such as Docker Hub and Quay.io
+- Cloud Provider registries such as GCR, ECR, ACR etc.
+- Self-hosted registries such as Docker Distribution and Harbor.
 
-Trow is very much in the self-hosted registry bucket, but has a different focus to the other
-solutions. Notably, it is expected that Trow would be used alongside one or more of the other
-solutions - from any of the buckets. In this set-up, Trow would provide fast distribution of images
-inside clusters, with the other registry providing long-term storage and potentially acting as the
+Trow is in the self-hosted registry bucket, but has a different focus to the other solutions.
+Notably, it is expected that Trow would be used alongside one or more of the other solutions - from any of the buckets.
+In this set-up, Trow would provide fast distribution of images inside clusters,
+with the other registry providing long-term storage and potentially acting as the
 source of images for Trow.
 
 Harbor is one of the most common options at the minute, so it's worth doing a direct comparison.
@@ -22,9 +24,11 @@ multiple teams and clusters.
 By contrast, Trow is designed to be much more lightweight and to run inside each cluster it serves.
 It also integrates with the cluster itself, for example by controlling which images can run in the
 cluster through a validating webhook - this allows you to say things like "only allow images from
-this registry to run or official images from the Docker Hub". A core aim for Trow is to develop
-advanced distribution mechanisms, possibly using P2P or similar techniques to transfer images to
-nodes as quickly as possible (meaning containers start up faster).
+this registry to run or official images from the Docker Hub".
+
+## To other caching solutions (spegel)
+
+### A caching solution ?
 
 As mentioned before, we hope and expect to see Trow working alongside other registries, including
 Harbor. In this case, the other registry (Harbor/GCR etc) would be a central store of all images and
@@ -32,12 +36,24 @@ would keep a full history the images. Trow would run inside each of the clusters
 and would distribute the working set of images to nodes. Trow would automatically pull images
 through from Harbor for use in the cluster. There a lot of potential benefits from this approach:
 
- - Images can be distributed faster - the Trow registries are local to the cluster which means a
-   shorter network trip - they effectively act as a local cache for the central registry.
- - Less stress on the central registries, which now only needs to serve the Trow registries,
-   rather than every node in the cluster.
- - Individual clusters can have differently configured registries that meet their distinct needs.
-   For example, a development cluster may have looser restrictions on where images can come from or
-   how to handle vulnerability scans than a production cluster.
+- Images can be distributed faster - the Trow registries are local to the cluster which means a
+  shorter network trip - they effectively act as a local cache for the central registry.
+- Less stress on the central registries, which now only needs to serve the Trow registries, rather than every node in the cluster.
+- Individual clusters can have differently configured registries that meet their distinct needs.
+  For example, a development cluster may have looser restrictions on where images can come from or
+  how to handle vulnerability scans than a production cluster.
 
-Please note that some of these points are based on features currently planned or in development.
+### Compared to Spegel
+
+[Spegel](https://github.com/spegel-org/spegel) is a stateless caching solution for `containerd`.
+
+| Feature | Spegel | Trow | description |
+| --- | :---: | :---: | --- |
+| Works with any kubernetes flavor<br/>and any container runtime | 🟥<br/>(planned?) | 🟩 | Spegel is a containerd plugin.<br/>Trow relies on K8S APIs. |
+| Low configurability | 🟩 | 🟩 | Both solutions are ~ plug and play. |
+| High Availability | 🟩 | 🟥<br/>(planned) | If spegel fails, the original registry is used. If Trow fails, the image can't be pulled. |
+| High performance | 🟩 | 🟨 | Trow has no P2P solution (relates to high availability) nor good benchmarks (_yet_). |
+| Is stateless (🧙) | 🟩 | 🟨<br/>(can use an ephemeral volume) | Spegel uses containerd's state. Trow has it's own state. |
+| Is stateful (💾) | 🟥 | 🟩 | You can air-gap Trow and kill the nodes it's running on, it will keep its state. |
+| Is also a registry | 🟥 | 🟩 | Relates to the stateless/stateful thing |
+| Does not duplicate images storage | 🟩 | 🟥 | Relates to the stateless/stateful thing |


### PR DESCRIPTION
The old docs doesn't really mention the caching capabilities of Trow, wich is my main use case currently.