### PR TITLE
remove duplicate label

### DIFF
--- a/charts/trow/templates/webhooks/service.yaml
+++ b/charts/trow/templates/webhooks/service.yaml
@@ -5,7 +5,6 @@ metadata:
   name: {{ include "trow.fullname" . }}-webhooks
   labels:
     {{- include "webhook.labels" . | nindent 4 }}
-    app.kubernetes.io/component: webhooks
   namespace: {{ .Release.Namespace }}
 spec:
   type: ClusterIP


### PR DESCRIPTION
The `app.kubernetes.io/component: webhooks` label also gets pulling in with `webhook.labels`