### PR TITLE
add ability to set pod and container security contexts

### DIFF
--- a/charts/trow/templates/statefulset.yaml
+++ b/charts/trow/templates/statefulset.yaml
@@ -62,10 +62,14 @@ spec:
         resources:
         {{- toYaml . | nindent 10 }}
       {{- end }}
+        {{- with .Values.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      {{- with .Values.podSecurityContext }}
       securityContext:
-        runAsUser: 333333
-        runAsGroup: 333333
-        fsGroup: 333333
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
       {{- if and (.Values.trow.user) (.Values.trow.password) }}
         - name: trow-pass

--- a/charts/trow/templates/webhooks/deployment.yaml
+++ b/charts/trow/templates/webhooks/deployment.yaml
@@ -30,6 +30,10 @@ spec:
           - |
             cp /etc/trow/webhook-cert-ecc/tls.crt /etc/trow/webhook-cert/cert && \
             openssl pkcs8 -topk8 -nocrypt -in /etc/trow/webhook-cert-ecc/tls.key -out /etc/trow/webhook-cert/key
+        {{- with .Values.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         volumeMounts:
         - name: webhook-cert-translated
           mountPath: /etc/trow/webhook-cert
@@ -53,6 +57,10 @@ spec:
         ports:
         - name: webhook
           containerPort: 8443
+        {{- with .Values.containerSecurityContext }}
+        securityContext:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         volumeMounts:
         - name: webhook-cert-translated
           mountPath: /etc/trow/webhook-cert
@@ -63,6 +71,10 @@ spec:
           subPath: config.yaml
           readOnly: true
       {{- end}}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       volumes:
         - name: webhook-cert-ecc
           secret:

--- a/charts/trow/templates/webhooks/tls-patch.yaml
+++ b/charts/trow/templates/webhooks/tls-patch.yaml
@@ -135,14 +135,16 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          {{- with .Values.webhooks.tls.patch.containerSecurityContext }}
           securityContext:
-            allowPrivilegeEscalation: false
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       restartPolicy: OnFailure
       serviceAccountName: {{ include "trow.fullname" . }}-webhooks-tls
+      {{- with .Values.webhooks.tls.patch.podSecurityContext }}
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 2000
-        fsGroup: 2000
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -184,8 +186,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          {{- with .Values.webhooks.tls.patch.containerSecurityContext }}
           securityContext:
-            allowPrivilegeEscalation: false
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- end }}
       {{- if .Values.trow.proxyRegistries.webhook.enabled }}
         - name: patch-mutation
@@ -203,13 +207,15 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+          {{- with .Values.webhooks.tls.patch.containerSecurityContext }}
           securityContext:
-            allowPrivilegeEscalation: false
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- end }}
       restartPolicy: OnFailure
       serviceAccountName: {{ include "trow.fullname" . }}-webhooks-tls
+      {{- with .Values.webhooks.tls.patch.podSecurityContext }}
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 2000
-        fsGroup: 2000
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end -}}

--- a/charts/trow/values.yaml
+++ b/charts/trow/values.yaml
@@ -9,6 +9,13 @@ image:
   tag:
   pullPolicy: IfNotPresent
 
+podSecurityContext:
+  runAsUser: 333333
+  runAsGroup: 333333
+  fsGroup: 333333
+
+containerSecurityContext: {}
+
 trow:
   ## if using NodePort, this can be set to 127.0.0.1:XXXX
   ## Where "XXXX" is the value of service.nodePort
@@ -76,6 +83,12 @@ webhooks:
       image:
         image: registry.k8s.io/ingress-nginx/kube-webhook-certgen:v1.4.4@sha256:a9f03b34a3cbfbb26d103a14046ab2c5130a80c3d69d526ff8063d2b37b9fd3f
         pullPolicy: IfNotPresent
+      podSecurityContext:
+        runAsNonRoot: true
+        runAsUser: 2000
+        fsGroup: 2000
+      containerSecurityContext:
+        allowPrivilegeEscalation: false
     ## Use an existing secret that contains tls.crt and tls.key
     existingSecretRef: ~
 

--- a/charts/trow/values.yaml
+++ b/charts/trow/values.yaml
@@ -9,6 +9,7 @@ image:
   tag:
   pullPolicy: IfNotPresent
 
+## Applies to the Trow Statefulset and the webhooks Deployment
 podSecurityContext:
   runAsUser: 333333
   runAsGroup: 333333


### PR DESCRIPTION
In order to run Trow in my cluster, I require extra security context options set. Normally, I would just by just using Helm postrendering, but it doesn't seem like postrendering works with Helm Chart Hooks. So I've added a way to set the security contexts.

The webhook deployment seems to typically use the same options as the statefulset, so that's what I've done here. However, with the same security context as the statefulset, the webhook deployment cannot create the data files it wants to in the default data-dir directoy. In my own deployment, I just set the data-dir to `/tmp`, but some decision would have to be made before this can be merged in without breaking the webhook deployment.